### PR TITLE
corresponding tcolorbox is set to breakable.

### DIFF
--- a/03/contents/chap03_02_2_15.tex
+++ b/03/contents/chap03_02_2_15.tex
@@ -1,6 +1,6 @@
 %　※いい感じに分割してください※
 
-\begin{tcolorbox}[title=\useOmetoi]
+\begin{tcolorbox}[title=\useOmetoi,breakable]
 \begin{figure}[H]
     \centering
     \includegraphics[width=0.6\linewidth]{images/chap03/text03-img029.png}


### PR DESCRIPTION
p.16 in text 03 contains a tcolorbox across the page but overflowed contents are not shown. Appending an option of breakable let the box be across a page.

TODO: all the tcolorbox-es should be breakable.

TODO: tcolorbox closes at the end of every page break even another contents continue; we expect the bottom or top of the box should be open to suggest that it continues on the other pages.