### PR TITLE
use dvipdfmx instead of dvipdfm

### DIFF
--- a/01/llmk.toml
+++ b/01/llmk.toml
@@ -1,5 +1,5 @@
 latex = "platex"
-dvipdf = "dvipdfm"
+dvipdf = "dvipdfmx"
 source = "text01.tex"
 
 sequence = ["latex", "dvipdf"] # Skip bibtex and makeindex

--- a/07/llmk.toml
+++ b/07/llmk.toml
@@ -1,5 +1,5 @@
 latex = "platex"
-dvipdf = "dvipdfm"
+dvipdf = "dvipdfmx"
 source = "text07.tex"
 
 sequence = ["latex", "dvipdf"] # Skip bibtex and makeindex

--- a/08/llmk.toml
+++ b/08/llmk.toml
@@ -1,5 +1,5 @@
 latex = "platex"
-dvipdf = "dvipdfm"
+dvipdf = "dvipdfmx"
 source = "text08.tex"
 
 sequence = ["latex", "dvipdf"] # Skip bibtex and makeindex

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,12 @@ FROM alpine:3.15.0
 ENV PATH /usr/local/bin/texlive:$PATH
 WORKDIR /install-tl-unx
 RUN apk add --no-cache \
+  fontconfig \
+  ghostscript \
   perl \
   tar \
   wget \
-  xz \
-  fontconfig
+  xz
 COPY ./prod/texlive.profile ./
 RUN wget -nv https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
 RUN tar -xzf ./install-tl-unx.tar.gz --strip-components=1


### PR DESCRIPTION
PDF への変換は `dvipdfmx` が前提のところ，誤って `dvipdfm` が指定されていたため修正した．

See related issue at https://github.com/OmeSatoFoundation/ome-doc/issues/121