### PR TITLE
[第3回] [第5回] [第6回] llmk.toml内でlualatexのオプション指定にoptアトリビュートを使うように変更

### DIFF
--- a/03/llmk.toml
+++ b/03/llmk.toml
@@ -3,4 +3,5 @@ source = "text03.tex"
 sequence = ["latex"] # Skip bibtex and makeindex
 
 [programs.latex]
-command = "lualatex --shell-escape --cnf-line='TEXINPUTS=.;../texmf//;'"
+command = "lualatex"
+opts = ["--shell-escape", "--cnf-line='TEXINPUTS=.;../texmf//;'"]

--- a/05/llmk.toml
+++ b/05/llmk.toml
@@ -3,4 +3,5 @@ source = "text05.tex"
 sequence = ["latex"] # Skip bibtex and makeindex
 
 [programs.latex]
-command = "lualatex --shell-escape --cnf-line='TEXINPUTS=.;../texmf//;'"
+command = "lualatex"
+opts  = ["--shell-escape", "--cnf-line='TEXINPUTS=.;../texmf//;'"]

--- a/06/llmk.toml
+++ b/06/llmk.toml
@@ -3,4 +3,5 @@ source = "text06.tex"
 sequence = ["latex"] # Skip bibtex and makeindex
 
 [programs.latex]
-command = "lualatex --shell-escape --cnf-line='TEXINPUTS=.;../texmf//;'"
+command = "lualatex"
+opts  = ["--shell-escape", "--cnf-line='TEXINPUTS=.;../texmf//;'"]


### PR DESCRIPTION
 llmk.toml内でlualatexのオプション指定を`command`内ではなく、`opt`アトリビュートを使う用に変更。