### PR TITLE
適切なサブセクションの設定

### DIFF
--- a/01/contents/chap01_02.tex
+++ b/01/contents/chap01_02.tex
@@ -71,13 +71,14 @@
 \clearpage
 
 \refstepcounter{Exercise}
-\subsection{\theExercise フォルダを作成しよう}
-これから、自分のフォルダを開き、フォルダを作成してもらいます。
-ですが、そのまえに注意してもらいたいことが１つあります。
+\subsection{\theExercise 自分のフォルダを確認しよう}
+まず、みなさんがこの授業で使う「自分のフォルダ」を確認しましょう。
+このとき、注意してもらいたいことが１つあります。
 さきほど、みなさんには「ユーザ名」と「パスワード」を設定してもらいました。
 そのとき設定した「ユーザ名」によって、みなさんひとりひとりの「自分のフォルダ」の名前が変わります。
-どこが変わるのか、じっさいに見てみましょう。
+どこが変わるのか、じっさいに見てみましょう。\\
 
+{\bf \large 考え方}\\
 \begin{figure}[ht]
 \begin{minipage}{\textwidth}
   \includegraphics[width=6.472cm,height=4.976cm]{textbook-img032.png}
@@ -92,72 +93,49 @@
 \hfill
 \begin{minipage}{0.4\textwidth}
   2
-  上の図のように、ファイルマネージャーが表示されます（ウィンドウの色が違うかもしれませんが、色はあとで変えられます）
-\end{minipage}\\
-この、ファイルマネージャの写真の赤枠で囲ったところには、
-/home/piと書いてあります。ですが、みなさんは違うはずです。
-ここに、さいしょに設定した「ユーザ名」が反映されます。
+  上の図のように、ファイルマネージャーが開いて、自分のフォルダが表示されます。（ウィンドウの色が違うかもしれませんが、色はあとで変えられます）
+\end{minipage}
+\end{figure}
+\\ファイルマネージャーは、初回起動時は自分のフォルダを表示します。
+この、ファイルマネージャの写真の赤枠で囲ったところには、自分のフォルダのパスが書いてあります。
+パスについての詳しい説明は、以降の回で出てくるので、今はとりあえずフォルダ、ファイルの「住所」と考えてください。
+この画像では、/home/piと書いてあります。ですが、みなさんは違うはずです。
+\textbf{\color{red}ここに、さいしょに設定した「ユーザ名」が反映されます。}
 たとえば、「takeshi」というユーザ名を設定した場合、この赤枠の中は、
-/home/takeshiになります。みなさんのファイルマネージャでは、何と書いてありますか？\\
+/home/takeshiになります。
 \vspace{20pt}
 
 \refstepcounter{Question}\theQuestion\\
 自分のフォルダのパス（右上の画像の赤い枠で囲まれた部分）を、下の空欄に書き写してみよう
 \includegraphics[width=17cm]{textbook-img1021.png}
-
-\vspace{20pt}
-\end{figure}
 \clearpage
 
-それでは、ファイルマネージャを使ってみましょう。\\Documentsフォルダ直下にtaro、hanako、saburoという名前のフォルダを作成しましょう。\\
+\refstepcounter{Exercise}
+\subsection{\theExercise フォルダを作成しよう}
+Documentsフォルダ直下にtaro、hanako、saburoという名前のフォルダを作成しましょう。\\
 
 {\bf \large 考え方}
-\vfill
 \begin{figure}[ht]
-  \begin{minipage}{\textwidth}
-    %[Warning: Image ignored] % Unhandled or unsupported graphics:
-    \includegraphics[width=6.472cm,height=4.976cm]{textbook-img032.png}
-    \includegraphics[width=2.094cm,height=1.771cm]{textbook-img035.png}
-    \includegraphics[width=8.301cm,height=4.948cm]{textbook-img033.png}
-  \end{minipage}
-  \begin{minipage}{0.4\textwidth}
-    1
-    ディスプレイの左上の　アイコンをクリック
-  \end{minipage}
-  \hfill
-  \begin{minipage}{0.4\textwidth}
-    2
-    上の図のようにファイルマネージャーが表示されます
-  \end{minipage}\\
-  \vspace{-12mm}
-  \hfill \includegraphics[width=1.771cm,height=2.094cm]{textbook-img037.png}
-  %\vspace{-5mm}
   \includegraphics[width=0.9\textwidth]{textbook-img034.png}
-  \begin{minipage}{15.758cm}
     \centering
-    3
-    右側の空白部分で右クリックし　「New Folder」を選んでクリック
-  \end{minipage}
+    \\1
+    ファイルマネージャーの空白部分で右クリックし　「New Folder」にカーソルを合わせてクリック
+    \vspace{60pt}
   \begin{minipage}{\textwidth}
     \includegraphics[width=0.9\textwidth]{textbook-img036.png}
   \end{minipage}
-  \begin{minipage}{12.336cm}
-    4
+    2
     フォルダ名の入力を求められるので、付けたい名前を入力しよう
-  \end{minipage}
 \end{figure}
 \clearpage
 {\bf\large 考え方(続き)}
-
-
-
 \begin{figure}[hb]
   \centering
   %[Warning: Image ignored] % Unhandled or unsupported graphics:
   \includegraphics[width=11.398cm,height=5.72cm]{textbook-img038.png}
   \centering
   \begin{minipage}{13.001cm}
-    5
+    3
     名前を入力し、OKを押すと上の画像のようにフォルダが作成されます
   \end{minipage}
 
@@ -1097,9 +1075,13 @@ Desktop直下に「space1」と「space2」を作り、「space1」の中に「m
       4 選び終えたら、自動的にウィンドウの色が変わっているよ
     \end{minipage}
 
+    \bigskip
+
+    \refstepcounter{Question}\theQuestion
+  
+    UIを好きな色に変えてみよう。
   \end{minipage}
 
-  \bigskip
 
 \end{figure}
 

--- a/01/contents/chap01_preamble.tex
+++ b/01/contents/chap01_preamble.tex
@@ -14,6 +14,7 @@
 \usepackage[dvipdfmx]{graphicx}
 %\usepackage{svg}
 \usepackage{bbding,pifont,wasysym,amssymb}
+\usepackage{color}
 
 \usepackage{docmute}
 % Outline numbering


### PR DESCRIPTION
fix #133 

「
P.16　どの文が例題なのか分からない。
ここでは、P.17の「Documents フォルダ直下に taro 、 hanako 、 saburo という名前のフォルダを作成しましょう。」が例題と思われるが、このセクション全体が「例題」となっている。セクション名を「フォルダの操作」など、具体的なものに変更し、実際に子どもたちが作業する例題部分を明示すること

セクションは操作の名前、セクション中に、操作の説明を記述。例題として、子どもたちが自分で行う操作を答え付きで示す
」
に対応

UI色のサブセクションが例題のみで、問題がなかったため、問題を追加

ユーザ名注意喚起の説明を修正、パスに関しての説明が第3回であるようなので、ここでは説明しない