### PR TITLE
教材コピー手順を例題として設定

### DIFF
--- a/01/contents/chap01_04.tex
+++ b/01/contents/chap01_04.tex
@@ -34,7 +34,8 @@
 \clearpage
 
 \begin{figure}
-\subsection{教材をじぶんのフォルダに置こう}
+\refstepcounter{Exercise}
+\subsection{\theExercise 教材をじぶんのフォルダに置こう}
 ホームページの作り方を学ぶための教材は、/usr/local/share/omeというフォルダに置いてあります。
 これを、じぶんのフォルダにコピーしましょう。
 


### PR DESCRIPTION
4章の、/usr/local/ome/shareから、教材をコピーする手順を例題として設定する。
シールカードを用いた進捗管理を考慮した変更。
