### PR TITLE
空欄を伴う問題について、空欄の高さを統一

### DIFF
--- a/01/contents/chap01_01.tex
+++ b/01/contents/chap01_01.tex
@@ -270,19 +270,8 @@
           \begin{itemize}
               \item
                   \refstepcounter{Question}\theQuestion 得た\ruby{知識}{ちしき}を\ruby{踏}{ふ}まえてパスワードとユーザ名を決めて下の\ruby{記入欄}{きにゅうらん}に記入してみましょう。
-                  \begin{table}[htbp]
-                    \centering
-
-                    \begin{tabular}{|c|c|}
-                    \hline
-                    \ruby{項目}{こうもく}&この列を\ruby{記入欄}{きにゅうらん}として\ruby{扱}{あつか}ってください  \\
-                        \hline
-                        ユーザー名(ID)& \\
-                        \hline
-                        パスワード& \\
-                        \hline
-                    \end{tabular}
-                    \end{table}
+                  \addBlank{ユーザ名（ID）}
+                  \addBlank{パスワード}
           \end{itemize}
           
           \clearpage
@@ -596,23 +585,8 @@
                         次にWi-Fiの\ruby{設定}{せってい}を行います。この\ruby{赤枠}{あかわく}の中に\ruby{接続可能}{せつぞくかのう}なWi-Fiの名前が\ruby{表示}{ひょうじ}されます。~\ref{seq:refFigure16}
                         \item
                         \refstepcounter{Question}\theQuestion またこのセクションではWi-FIのアドレスとパスワードが必要となるのでTA(ティーチングアシスタント(Teaching Assistant))の人からアドレスとパスワードを教えてもらい、下の\ruby{欄}{らん}に記入しておきましょう。
-                        \begin{table}[htbp]
-                          \centering
-
-                          \begin{tabular}{|c|c|}
-                          \hline
-                              \ruby{項目}{こうもく}&この列を\ruby{記入欄}{きにゅうらん}として\ruby{扱}{あつか}ってください  \\
-                              \hline
-                              （例）Wi-Fiアドレス& ALGS630-12345678\\
-                              \hline
-                              （例）パスワード& 12345678910\\
-                              \hline
-                              Wi-Fiアドレス& \\
-                              \hline
-                              パスワード& \\
-                              \hline
-                          \end{tabular}
-                          \end{table}
+                        \addBlank{Wi-Fiアドレス}
+                        \addBlank{パスワード}
                         \item
                         上部で記入したアドレスを\ruby{選択}{せんたく}してNextのボタンを\ruby{押}{お}します。
                         \begin{figure}[h]
@@ -633,7 +607,7 @@
                         \centering
                         \begin{minipage}{5.228cm}
                           {\upshape
-                            \includegraphics[width=10.000cm]{pswd_image_0404.png}
+                            \includegraphics[width=9.000cm]{pswd_image_0404.png}
                             \newline
                             {\refstepcounter{Figure}\theFigure\label{seq:refFigure17}}:
                             パスワード入力}

--- a/01/contents/chap01_02.tex
+++ b/01/contents/chap01_02.tex
@@ -94,7 +94,7 @@
 \begin{minipage}{0.5\textwidth}
   \vspace{20pt}
   2
-  上の図のように、ファイルマネージャーが開いて、自分のフォルダが\ruby{表示}{ひょうじ}されます。（ウィンドウの色が\ruby{違}{ちが}うかもしれませんが、色はあとで変えられます）
+  ファイルマネージャーが開いて、自分のフォルダが\ruby{表示}{ひょうじ}されます。（ウィンドウの色が\ruby{違}{ちが}うかもしれませんが、色はあとで変えられます）
 \end{minipage}
 \end{figure}
 \\ファイルマネージャーは、初回起動時は自分のフォルダを\ruby{表示}{ひょうじ}します。
@@ -108,7 +108,7 @@
 
 \refstepcounter{Question}\theQuestion\\
 自分のフォルダのパス（右上の\ruby{画像}{がぞう}の赤い\ruby{枠}{わく}で囲まれた部分）を、下の\ruby{空欄}{くうらん}に書き写してみよう
-\includegraphics[width=17cm]{textbook-img1021.png}
+\addBlank{答え}
 \clearpage
 
 \refstepcounter{Exercise}

--- a/01/contents/chap01_preamble.tex
+++ b/01/contents/chap01_preamble.tex
@@ -67,3 +67,9 @@
 \renewcommand\theExercise{例題 1-\arabic{Exercise}}
 \renewcommand\theQuestion{\textbf{問題 1-\arabic{Question}}}
 \renewcommand\theFigure{図\arabic{Figure}}
+
+% 空欄挿入マクロ　引数は空欄の左端の回答ラベル
+\newcommand{\addBlank}[1]{%
+\vspace{16mm} \\%
+\underline{\begin{minipage}{\linewidth}#1：\end{minipage}}\\
+}


### PR DESCRIPTION
fix #208 
会津大作成のマクロをベースに、スペース要件を満たした解答欄を生成可能にした。

この変更にあたって、Wi-Fi設定の問題内容に一部変更を行った。変更前は、Wi-Fiアドレスとパスワードの例が記されていたが、レイアウトの都合上省いた。これに関するissue #178 では、「当日、TAからWiFiアクセスポイントとパスワードを各グループごとに指定するので、TAから聞いたアクセスポイントとパスワードをテキストにメモを取らせてください。（課題として追加）」と先生がおっしゃっているので、記入欄だけ確保すれば最低要件は満たしていると考えたため、Wi-Fiアドレスとパスワードの例は削除した。
![image](https://github.com/OmeSatoFoundation/ome-doc/assets/78594153/591e3fc4-3bcc-4d61-ae5b-994553994a14)
変更後
![image](https://github.com/OmeSatoFoundation/ome-doc/assets/78594153/64df6e0a-387d-4753-b174-1774dc76b55a)
