### PR TITLE
bizudフォントの対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,15 @@ RUN wget https://github.com/liberationfonts/liberation-fonts/files/7261482/liber
     && wget https://noto-website-2.storage.googleapis.com/pkgs/NotoSerifCJKjp-hinted.zip \
     && unzip -o NotoSerifCJKjp-hinted.zip \
     && mv *.otf /usr/share/fonts/TTF \
+    && wget https://github.com/google/fonts/raw/main/ofl/bizudgothic/BIZUDGothic-Bold.ttf \
+        https://github.com/google/fonts/raw/main/ofl/bizudgothic/BIZUDGothic-Regular.ttf \
+        https://github.com/google/fonts/raw/main/ofl/bizudmincho/BIZUDMincho-Bold.ttf \
+        https://github.com/google/fonts/raw/main/ofl/bizudmincho/BIZUDMincho-Regular.ttf \
+        https://github.com/google/fonts/raw/main/ofl/bizudpgothic/BIZUDPGothic-Bold.ttf \
+        https://github.com/google/fonts/raw/main/ofl/bizudpgothic/BIZUDPGothic-Regular.ttf \
+        https://github.com/google/fonts/raw/main/ofl/bizudpmincho/BIZUDPMincho-Bold.ttf \
+        https://github.com/google/fonts/raw/main/ofl/bizudpmincho/BIZUDPMincho-Regular.ttf \
+    && mv *.ttf /usr/share/fonts/TTF \
     && rm -r ~/fonts
 
 RUN echo -e '\

--- a/texmf/tex/luatexja/omebook/omebook.sty
+++ b/texmf/tex/luatexja/omebook/omebook.sty
@@ -1,5 +1,4 @@
 % style file for ltjsbook
-% by Hogenimushi
 
 % 傍注スペースを削る
 \addtolength{\fullwidth}{-26truemm} %全体の幅(ヘッダ部の幅)を既定値から26mm小さくする
@@ -7,10 +6,37 @@
 \setlength{\evensidemargin}{1truemm}    %偶数ページの左余白を1mm(+1インチ)にする
 \setlength{\oddsidemargin}{19truemm}    %奇数ページの左余白を19mm(+1インチ)にする
 
-% フォントは最終段階で決定する
+% フォントは最終段階で決定する。bizudの設定は
+% https://qiita.com/kakinaguru_zo/items/22c4db21e03d4608e300
+% をGoogle fontsで配布されているフォント用に修正
 %\usepackage[ipaex]{luatexja-preset}
-\usepackage[haranoaji,deluxe]{luatexja-preset}
-\usepackage{luatexja-otf}
+%\usepackage[haranoaji,deluxe]{luatexja-preset}
+%\usepackage{luatexja-otf}
+\usepackage{luatexja-fontspec}
+\newjfontface{\nonproportional}{BIZ UDMincho}[YokoFeatures={JFM=ujis}]
+\setmainjfont[Ligatures={Common,TeX},
+  ItalicFont={BIZ UDPMincho},
+  ItalicFeatures={FakeSlant=0.27},
+  SlantedFont={BIZ UDPMincho},
+  SlantedFeatures={FakeSlant=0.18},
+  BoldFont={BIZ UDPGothic Bold},
+  BoldSlantedFont={BIZ UDPGothic Bold},
+  BoldSlantedFeatures={FakeSlant=0.18},
+  BoldItalicFont={BIZ UDPGothic Bold},
+  BoldItalicFeatures={FakeSlant=0.27},
+  YokoFeatures={JFM=prop}]{BIZ UDPMincho}
+%\newjfontface{\nonproportional}{BIZ UDGothic}[YokoFeatures={JFM=ujis}]
+\setsansjfont[Ligatures={Common,TeX},
+  ItalicFont={BIZ UDPGothic},
+  ItalicFeatures={FakeSlant=0.23},
+  SlantedFont={BIZ UDPGothic},
+  SlantedFeatures={FakeSlant=0.23},
+  BoldFont={BIZ UDPGothic Bold},
+  BoldSlantedFont={BIZ UDPGothic Bold},
+  BoldSlantedFeatures={FakeSlant=0.23},
+  BoldItalicFont={BIZ UDPGothic Bold},
+  BoldItalicFeatures={FakeSlant=0.23},
+  YokoFeatures={JFM=prop}]{BIZ UDPGothic}
 
 \usepackage{graphicx}
 \usepackage{color}


### PR DESCRIPTION
omebookをGoogle Fontsで公開されているモリサワbiz ud 明朝とゴシックに対応させました。
LaTeX用Dockerの再ビルド（かフォントを自分で無理やり入れる）が必要です。
