### PR TITLE
[第3回] Typo修正

### DIFF
--- a/03/contents/chap03_02_2_8.tex
+++ b/03/contents/chap03_02_2_8.tex
@@ -10,7 +10,7 @@
 <#green#pi@raspberrypi#>:<#blue#~ $#> cd ~/rika
 <#green#pi@raspberrypi#>:<#blue#~ $#> mv rika2.png bika.png
 <#green#pi@raspberrypi#>:<#blue#~ $#> ls -F
-<#magenta#bika.png	mokei.png		rika.png.#>
+<#magenta#bika.png	mokei.png		rika.png#>
 \end{lstlisting}
 
 \begin{tcolorbox}[title=\useOmetoi]


### PR DESCRIPTION
第3回の教科書の`.png.`を`.png`へ修正