### PR TITLE
improve appearance in ls command explanation

### DIFF
--- a/03/contents/chap03_01.tex
+++ b/03/contents/chap03_01.tex
@@ -85,12 +85,14 @@ Fは大文字なので注意してください。
 \end{description}
 
 %//terminal[lsF-test][ls -F コマンドの例]{
-\begin{lstlisting}[caption=ls -F コマンドの例,label=lsFtest]
+\begin{minipage}{\linewidth}
+\begin{lstlisting}[caption=ls -F コマンドの例。ファイルやディレクトリが表示されます,label=lsFtest]
 <#green#pi@raspberrypi#>:<#blue#~ $#> ls -F
 <#blue#01  03         Desktop    Downloads  Pictures  Templates
-02  Bookshelf  Documents  Music      Public    Videos#> <--ファイルやディレクトリが表示されます
+02  Bookshelf  Documents  Music      Public    Videos#>
 <#green#pi@raspberrypi#>:<#blue#~ $#>
 \end{lstlisting}
+\end{minipage}
 
 \begin{itemize}
 \item[<例>] ls\textvisiblespace -Fだけを入力するとカレントディレクトリの中を見ることができます。 


### PR DESCRIPTION
Closes #261 again.

1) prohibit page break in listings
2) position the comment to the caption from inside the code block