### PR TITLE
第７，８回 例題問題番号のカウンタ設定、一部問題に変更

### DIFF
--- a/07/text07.tex
+++ b/07/text07.tex
@@ -30,7 +30,10 @@
 \vspace{16mm}\leavevmode \\%
 \underline{\begin{minipage}{\linewidth}#1：\end{minipage}}\\
 }
-
+\newcounter{Exercise}
+\newcounter{Question}
+\renewcommand\theExercise{例題 7-\arabic{Exercise}}
+\renewcommand\theQuestion{\textbf{問題 7-\arabic{Question}}}
 % Outline numbering
 \setcounter{secnumdepth}{2}
 \renewcommand\thesection{\arabic{section}}
@@ -169,7 +172,7 @@
 
 \vfill
 
-\textbf{問題７−１}　みんなが使っているパソコンやスマートフォンなどをたくさんつなぎ、おたがいに情報の交換ができるようにしたものを何というでしょうか。
+\refstepcounter{Question}\theQuestion　みんなが使っているパソコンやスマートフォンなどをたくさんつなぎ、おたがいに情報の交換ができるようにしたものを何というでしょうか。
 
 
 
@@ -267,14 +270,13 @@ IPアドレスにはグローバルIPアドレスとローカル（プライベ�
 \includegraphics[width=15.0cm,height=10.0cm]{ome7-img006}
 \flushleft
 
-{\bfseries
-	問題７−２　ローカルIPアドレスがかぶっても良いときはどのときですか。}
+{\refstepcounter{Question}\theQuestion　ローカルIPアドレスがかぶっても良いときはどのときですか。}
 
 {\bfseries
 	\addBlank{答え}}
 
-\clearpage\subsection*{\bfseries 例題7-1
-	IPアドレスを調べてみよう}
+	\refstepcounter{Exercise}
+\clearpage\subsection*{\theExercise　IPアドレスを調べてみよう}
 ターミナルにコマンド”hostname
 -\texttt{I}”を入力し、自分のラズベリーパイのローカルIPアドレスを確認しよう
 
@@ -449,7 +451,7 @@ IPアドレスにはグローバルIPアドレスとローカル（プライベ�
 
 \bigskip
 
-\textbf{問題７−３}　ルータはラズベリーパイたちを見分けるために何を割り当てていますか。
+\refstepcounter{Question}\theQuestion　ルータはラズベリーパイたちを見分けるために何を割り当てていますか。
 
 \bigskip
 
@@ -457,8 +459,8 @@ IPアドレスにはグローバルIPアドレスとローカル（プライベ�
 \bigskip
 \addBlank{答え}
 
-\clearpage\subsection*{\bfseries 例題7-2\textmd{
-	}ポケットWi-FiルータのグローバルIPアドレスを調べよう}
+\refstepcounter{Exercise}
+\clearpage\subsection*{\theExercise　ポケットWi-FiルータのグローバルIPアドレスを調べよう}
 \begin{minipage}[b]{0.58\textwidth}
 	ターミナルを開き、”curl
 	inet-ip.info”とコマンドを入力して、自分のラズベリーパイが接続しているwifiルータのグローバルIPアドレスを確認しよう
@@ -587,7 +589,7 @@ IPアドレスでは通信相手となる別のネットワークのコンピュ
 \bigskip
 
 
-\textbf{問題７−４}　ポート番号はどのようなことに使われますか。
+\refstepcounter{Question}\theQuestion　ポート番号はどのようなことに使われますか。
 \bigskip
 
 \addBlank{答え}
@@ -658,8 +660,7 @@ IPアドレスでは通信相手となる別のネットワークのコンピュ
 
 \bigskip
 
-{\bfseries
-	問題7−5　コンピュータ上のプログラムを判断するためになにが用いられていますか。}
+{\refstepcounter{Question}\theQuestion　コンピュータ上のプログラムを判断するためになにが用いられていますか。}
 \bigskip
 
 {\bfseries
@@ -717,8 +718,7 @@ IPアドレスでは通信相手となる別のネットワークのコンピュ
 
 \bigskip
 
-{\bfseries
-	問題７−６　ターミナルを開き、”host
+{\refstepcounter{Question}\theQuestion　ターミナルを開き、”host
 	amazon.co.jp”を実行してグローバルIPアドレスを確認しよう。}
 
 \bigskip
@@ -762,8 +762,8 @@ Translation）というものを用います。このNATはルータが行って
 
 \bigskip
 
-\clearpage\subsection*{\bfseries 例題7-3
-	開いているポートを調べてみよう}
+\refstepcounter{Exercise}
+\clearpage\subsection*{\theExercise　開いているポートを調べてみよう}
 ターミナルを開き、”nmap
 localhost”とコマンドを入力し、ポートについて知ろう
 
@@ -843,7 +843,8 @@ serviceに出てきた言葉をインターネットを使って調べよう。
 }
 
 \clearpage\subsection*{２−１　HTMLについて}
-\subsection*{例題7-4 HTMLの復習}
+\refstepcounter{Exercise}
+\subsection*{\theExercise　HTMLの復習}
 {\bfseries
 	考え方\newline
 	第１回で作成した自己紹介ページのタグや機能を理解することでHTMLについて自分の思ったとおりに作れるようになりましょう。}
@@ -1050,7 +1051,7 @@ HTMLで使いたい色を探すときにはここを使うと便利です。
 \bigskip
 
 \clearpage
-\textbf{問題7−7}\newline
+\refstepcounter{Question}\theQuestion\newline
 \begin{enumerate}
 	\item 最初に書いたテキストボックスの属性をパスワード入力ボックスに書き換えてみよう。
 	\item 食べ物の名前を{\textless}p{\textgreater}タグを使って３つ追加してその横にチェックボックスを置きましょう。
@@ -1101,8 +1102,8 @@ inputタグの機能になるもの
 
 \bigskip
 
-\clearpage\subsection*{2−2　例題7-5
-	自分のホームページを公開しよう}
+\refstepcounter{Exercise}
+\clearpage\subsection*{2−2　\theExercise　自分のホームページを公開しよう}
 考え方
 
 クライアントとサーバーと呼ばれるコンピュータがあります。クライアントとはサービスを利用するコンピュータです。サーバーとはそれと逆にサービスを提供しているコンピュータです。クライアントとサーバーは同じコンピュータにあっても
@@ -1230,8 +1231,8 @@ OK です。例えば、google
 
 \bigskip
 
-\clearpage\subsection*{2−3　例題7-6
-	友だちのホームページを見てみよう}
+\refstepcounter{Exercise}
+\clearpage\subsection*{2−3　\theExercise　友だちのホームページを見てみよう}
 
 
 \centering
@@ -1321,8 +1322,7 @@ OK です。例えば、google
 
 \bigskip
 
-{\bfseries
-	問題7−8}　他のグループの友達のホームページを見てみよう、自分とは違うwifiルータに接続している友達のホームページは見れたかどうか答えに書こう
+\refstepcounter{Question}\theQuestion　他のグループの友達のホームページを見てみよう、自分とは違うwifiルータに接続している友達のホームページは見れたかどうか答えに書こう
 
 
 \bigskip
@@ -1414,7 +1414,7 @@ CGIを使った動的ページでは、サーバーが皆さんからwebペー�
 
 \bigskip
 
-\bfseries{問題7−9}　動的なページとはどのようなものでしょうか。また、動的なページを作成する場合に用いるものは何でしょう。
+\refstepcounter{Question}\theQuestion　動的なページとはどのようなものでしょうか。また、動的なページを作成する場合に用いるものは何でしょう。
 
 
 \bigskip
@@ -1429,8 +1429,9 @@ CGIを使った動的ページでは、サーバーが皆さんからwebペー�
 
 \bigskip
 
-\clearpage\subsection*{\rmfamily 例題7-7
-	CGIを使ってウェブページからLEDをつける}
+\refstepcounter{Exercise}
+\clearpage\subsection*{\theExercise　CGIを使ってウェブページからLEDをつける}
+\addtocounter{Exercise}{-1}\refstepcounter{Exercise}\label{E:CGI}
 考え方
 
 ウェブサーバはウェブブラウザから要求を受けます。”ファイル名.hsp”ファイルへのアクセスをブラウザから行うとサーバはCGIプログラムをサーバ側で起動します。結果はHTMLとしてブラウザ（クライアント）へ返されます。
@@ -1673,8 +1674,8 @@ end
 \bigskip
 
 
-\bigskip{\bfseries
-	問題7−10}
+\bigskip
+\refstepcounter{Question}\theQuestion
 
 {\bfseries
 	友達のLEDをCGIで点灯させてみよう。}
@@ -1692,8 +1693,9 @@ end
 
 \bigskip
 
-\clearpage\subsection*{\rmfamily 例題7-8
-	URLを使ってCGIに情報を渡す}
+\refstepcounter{Exercise}
+\clearpage\subsection*{\theExercise　URLを使ってCGIに情報を渡す}
+\addtocounter{Exercise}{-1}\refstepcounter{Exercise}\label{E:URL}
 考え方
 
 CGIのプログラムに情報を渡すことができればより便利なプログラムが作れます。ここでは単純なURLを用いた方法を使います。URLに埋め込まれた情報はクエリストリングと呼ばれます。クエリストリングはまずウェブサーバへ送られ、ウェブサーバがCGIプログラムへクエリストリングを渡します。これによりCGIプログラムはURLに埋め込まれた情報を扱うことができます。
@@ -1813,11 +1815,11 @@ localhost:3000/cgi-bin/querystring.hsp?msg=helloworld
 
 \bigskip
 
-{\bfseries
-	問題7−11}　画面に”ありがとう”と表示させよう。
+\refstepcounter{Question}\theQuestion　画面に”ありがとう”と表示させよう。
 
-\clearpage\subsection*{\rmfamily 例題7-9
-	クエリストリングを使ってLEDを操作する}
+	\refstepcounter{Exercise}
+\clearpage\subsection*{\theExercise　クエリストリングを使ってLEDを操作する}
+\addtocounter{Exercise}{-1}\refstepcounter{Exercise}\label{E:QS}
 この例では、クエリストリングを使ってLEDを点灯消灯させてみましょう。
 
 
@@ -1983,8 +1985,7 @@ cgpio命令は数値でGPIO番号、オンオフ（１，０）を受け付け�
 
 \bigskip
 
-{\bfseries
-	問題7−12}
+\refstepcounter{Question}\theQuestion
 
 {\bfseries
 	GPIO17以外のLEDを光らせてみよう。}
@@ -1995,8 +1996,9 @@ cgpio命令は数値でGPIO番号、オンオフ（１，０）を受け付け�
 
 \bigskip
 
-\clearpage\subsection*{\rmfamily 例題7-10
-	CGIを使ってOpenJtalkに読み上げをさせよう}
+\refstepcounter{Exercise}
+\clearpage\subsection*{\theExercise　CGIを使ってOpenJtalkに読み上げをさせよう}
+\addtocounter{Exercise}{-1}\refstepcounter{Exercise}\label{E:Jtalk}
 考え方
 
 ウェブページから読み上げさせたい文章を受け取って、OpenJtalkにCGIから読み上げをさせよう。
@@ -2239,8 +2241,8 @@ controlsをつけると、再生ボタン、ミュートボタンなどが表示
 
 再生ボタンを押すと音声合成した音声ファイルが再生されます。
 
-\clearpage{\bfseries
-	問題7−13}
+\clearpage
+\refstepcounter{Question}\theQuestion
 
 {\bfseries
 	”おはようございます””こんばんは””ありがとうございます”を読ませてみよう。}
@@ -2252,8 +2254,9 @@ controlsをつけると、再生ボタン、ミュートボタンなどが表示
 
 \ HINT: jtalk.htmlを参考にしてください。
 
-\clearpage\subsection*{\rmfamily 例題7-11
-	CGIでセンサーの情報を表示させる}
+\refstepcounter{Exercise}
+\clearpage\subsection*{\theExercise　CGIでセンサーの情報を表示させる}
+\addtocounter{Exercise}{-1}\refstepcounter{Exercise}\label{E:Sensors}
 考え方
 
 温度、温度、気圧、照度センサーの情報をCGIを使ってウェブページから見れるようにしましょう。
@@ -2396,8 +2399,8 @@ lux変数へ入っています。
 
 \bigskip
 
-\clearpage{\bfseries
-	問題7-14}
+\clearpage
+\refstepcounter{Question}\theQuestion
 
 友達のCGIへアクセスして、センサーの値を確認してみよう。
 
@@ -2427,8 +2430,9 @@ lux変数へ入っています。
 
 次は、湿度、気圧、照度センサーの値を表形式で表示するように変更してみましょう。
 
-\clearpage\subsection*{例題7-12
-	赤外線をウェブページから送信する}
+\refstepcounter{Exercise}
+\clearpage\subsection*{\theExercise　赤外線をウェブページから送信する}
+\addtocounter{Exercise}{-1}\refstepcounter{Exercise}\label{E:IR}
 CGIを使ってウェブページから赤外線を送信できるようにしましょう。
 
 まずは、サンプルを動かしてみましょう。
@@ -2615,8 +2619,8 @@ name={\textquotedbl}command{\textquotedbl}{\textgreater}
 
 \bigskip
 
-\bigskip{\bfseries
-	問題7−15}
+\bigskip
+\refstepcounter{Question}\theQuestion
 
 ファンの電源をつける以外の赤外線送信機能を追加してみよう。
 
@@ -2650,13 +2654,13 @@ CGIを使うときに便利なHSPの命令一覧
 		\#include “cgi.as”
 
 		getqueryval “name”, var &
-		7-8
+		\ref*{E:URL}
 
-		7-9
+		\ref*{E:QS}
 
-		7-10
+		\ref*{E:Jtalk}
 
-		7-12 &
+		\ref*{E:IR} &
 		クエリストリングから名前”name”を探して文字列として値を変数varへ入れる。
 
 		\textbf{localhost:3000/cgi-bin/querystring.hsp?name=val}
@@ -2665,11 +2669,11 @@ CGIを使うときに便利なHSPの命令一覧
 
 		\#include “rpz-gpio-cl.as”
 		cgpio 17, 1&
-		7-7
+		\ref*{E:CGI}
 
-		7-9
+		\ref*{E:QS}
 
-		7-11&
+		\ref*{E:Sensors} &
 		gpio 命令と使い方は同じ。GPIO17 番に 1 を
 		書き込む。gpio 命令との違いはプログラム終
 		了時にも書き込んだ値が持続する。例えば、
@@ -2679,17 +2683,17 @@ CGIを使うときに便利なHSPの命令一覧
 
 		\#include “rpz-gpio-cl.as”
 		onoff = cgpioin(17)&
-		7-7&
+		\ref*{E:CGI} &
 		gpio 命令と同じ。cgpio でプログラム終了時
 		でも効果を持続させたい場合はこちらを使用
 		する必要がある。\\\hline
 
 		\#include “rpz-gpio-cl.as”&
-		7-7
+		\ref*{E:CGI}
 
-		7-9
+		\ref*{E:QS}
 
-		7-11&
+		\ref*{E:Sensors} &
 		\#include “rpz-gpio.as”のコマンドライン版
 		コマンドラインや CGI で動くプログラムを書
 		く場合はこちらを使う。cgpio, cgpioin 命令
@@ -2698,7 +2702,7 @@ CGIを使うときに便利なHSPの命令一覧
 		\#include “jtalk.as”
 
 		jtsave “こんにちは”, hello &
-		7-10 &
+		\ref*{E:Jtalk} &
 		“こんにちは”をOpenJtalkで音声合成をして、作った音声ファイルのファイル名をhello変数へ入れる。音声ファイルは/tmp/ディレクトリの下にランダムなファイル名で入る。
 
 		例えば、hello変数の中身は

--- a/08/text08.tex
+++ b/08/text08.tex
@@ -388,8 +388,8 @@ curlコマンドを何もオプションをつけないで実行すると、タ�
 ”いわきあおと”のウェブページのHTMLファイルがダウンロードできていることが確認できました。
 
 次はダウンロードしたHTMLファイルから情報を取り出してみよう。
-
-\clearpage\subsection*{問題8-1}
+\refstepcounter{Question}
+\clearpage\subsection*{\theQuestion}
 \begin{itemize}
 \item curl
 を使って、グループの友達全員のウェブページを保存しよう。
@@ -399,7 +399,8 @@ curlコマンドを何もオプションをつけないで実行すると、タ�
 
 \ \ \ \ (例: koyama.html) 
 
-\subsection*{問題8-2}
+\refstepcounter{Question}
+\subsection*{\theQuestion}
 \begin{itemize}
 \item
 leafpadを使ってダウンロードしたHTMLファイルを開いて友達の名前を確認してみよう
@@ -748,7 +749,8 @@ src変数のタグを取り外してタグの間にあるテキストだけに�
 例えば、次の例で試すアメダスとよばれる気象情報観測システムの観測情報（気温、降水確率）などの情報を取り出し、LEDなどのセンサーと組み合わせます。
 実現したいアイディアがあったらメモをしておきましょう。
 
-\clearpage\subsection*{問題8-3}
+\refstepcounter{Question}
+\clearpage\subsection*{\theQuestion}
 \begin{itemize}
 \item
 残りのグループ内の友達のウェブページのタイトルを取り出してみよう
@@ -758,14 +760,16 @@ firend\_ipでダウンロードしたい友達のIPアドレスを指定する
 
 \ \ \ \ メモした友達のIPアドレスを使おう
 
-\subsection*{問題8-4}
+\refstepcounter{Question}
+\subsection*{\theQuestion}
 \begin{itemize}
 \item 13行目 curl url, htmlの下の行にmes
 htmlを追加して、実際にダウンロードされたHTMLを確認してみよう
 \end{itemize}
 \ \ HINT : 14行目にmes htmlを書く
 
-\subsection*{問題8-5}
+\refstepcounter{Question}
+\subsection*{\theQuestion}
 \begin{itemize}
 \item 15行目のhtmltag html, “title”,
 tagの”title”を”ol”に変更してみましょう
@@ -781,7 +785,8 @@ tag命令はtag変数の中に、
 タグを探して、結果を入れてくれます。
 
 
-\subsection*{問題8-6}
+\refstepcounter{Question}
+\subsection*{\theQuestion}
 \begin{itemize}
 \item 15行目のhtmltag html, “title”,
 tagの”title”を探したいタグへ変更しよう
@@ -894,17 +899,20 @@ Char(Character)は文字を意味します。}
 {\bfseries
 [\url{https://simple.wikipedia.org/wiki/ASCII}]}
 
-\clearpage\subsection*{問題 8-7}
+\refstepcounter{Question}
+\clearpage\subsection*{\theQuestion}
 \begin{itemize}
 \item
 ASCIIを使ってローマ字で自分の名前を表示させてみよう
 \end{itemize}
-\subsection*{問題8-8}
+\refstepcounter{Question}
+\subsection*{\theQuestion}
 \begin{itemize}
 \item
 ASCIIを使ってローマ字でとなりの友達の名前を表示させてみよう
 \end{itemize}
-\subsection*{問題8-9}
+\refstepcounter{Question}
+\subsection*{\theQuestion}
 \begin{itemize}
 \item
 ASCIIで顔文字を作って表示させてみよう
@@ -979,12 +987,14 @@ E3 81 80 + 2 = E3 81 82
 
 {\textbackslash}xはHE\textbf{X}(16進数であることを指定します)
 
-\clearpage\subsection*{問題 8-10}
+\refstepcounter{Question}
+\clearpage\subsection*{\theQuestion}
 \begin{itemize}
 \item
 UTF-8を使ってひらがなで自分の名前を表示させてみよう
 \end{itemize}
-\subsection*{問題8-11}
+\refstepcounter{Question}
+\subsection*{\theQuestion}
 \begin{itemize}
 \item
 UTF-8を使ってひらがなでとなりの友達の名前を表示させてみよう
@@ -1482,7 +1492,8 @@ orange ← “オレンジ”\\\hline
 
 mes jikan + {\textquotedbl} \ {\textquotedbl} + kion + {\textquotedbl} \ \ {\textquotedbl} + kousui
 
-\clearpage\subsection*{問題8-12}
+\refstepcounter{Question}
+\clearpage\subsection*{\theQuestion}
 \begin{itemize}
 \item
 .例題のプログラムでは、日時、気温、降水だけ表示しています。
@@ -1492,7 +1503,8 @@ mes jikan + {\textquotedbl} \ {\textquotedbl} + kion + {\textquotedbl} \ \ {\tex
 \ \ HINT : それぞれkazamuki, fusoku,
 nisyouという変数に情報が入っています。
 
-\subsection*{問題 8-13}
+\refstepcounter{Question}
+\subsection*{\theQuestion}
 \begin{itemize}
 \item
 kionが25.0度以上のときに、現在の気温を表示し、センサーボードの赤色LEDをつけてみましょう。
@@ -1527,7 +1539,8 @@ kionが25.0度以上のときに、現在の気温を表示し、センサーボ
 
 \bigskip
 
-\subsection*{問題 8-14}
+\refstepcounter{Question}
+\subsection*{\theQuestion}
 \begin{itemize}
 \item
 このアメダスのスクレイピングの例題とすでに習った技術（センサーボードの使い方、ゲーム、Fabo、赤外線など）と組み合わせるとどんなことができるか考えて、１つ上げてみよう。
@@ -1952,7 +1965,8 @@ kionを数値に変換して、28と大小の比較をしています。
 
 \bigskip
 
-\clearpage\subsection*{問題8-15}
+\refstepcounter{Question}
+\clearpage\subsection*{\theQuestion}
 \begin{itemize}
 \item
 例題では気温を文字列から数値へ変換しましたが、変数へは値をいれていません。
@@ -1963,19 +1977,22 @@ kionを数値に変換して、28と大小の比較をしています。
 
 \ \ \ \ 気温(kion)を数値へ変換した値をtemp変数へ入れる。
 
-\subsection*{問題8-16}
+\refstepcounter{Question}
+\subsection*{\theQuestion}
 \begin{itemize}
 \item
 現在の風速も表示するようにしてみよう
 \end{itemize}
-\subsection*{問題8-17}
+\refstepcounter{Question}
+\subsection*{\theQuestion}
 \begin{itemize}
 \item
 例題では、気温を使って比較をしました。
 		次は風向きを使用して風が強いとき(15m/sより大きい)は”強風に注意しましょう”と表示をしてLEDを光らせましょう。
 		それ以外の場合は”現在の風速”を表示して他の色のLEDを光らせましょう。
 \end{itemize}
-\subsection*{問題8-18}
+\refstepcounter{Question}
+\subsection*{\theQuestion}
 \begin{itemize}
 \item
 LEDだけでなくFaboなどのセンサーを使用して通知するようにしてみよう。
@@ -1988,7 +2005,8 @@ LEDだけでなくFaboなどのセンサーを使用して通知するように�
 
 \bigskip
 
-\subsection*{問題 8-19}
+\refstepcounter{Question}
+\subsection*{\theQuestion}
 \begin{itemize}
 \item
 センサーボードについている4つのLEDを使って、現在の温度を表すバーグラフを作ってみよう。
@@ -2011,8 +2029,9 @@ LEDの色は左からLED1(緑)、LED2(黄)、LED3(青)、LED4(白)です。
 
 \bigskip
 
-\clearpage\section*{問題8-20
-TV番組表のウェブページをスクレイピングする}
+\refstepcounter{Exercise}
+\clearpage\section*{\theExercise　TV番組表のウェブページをスクレイピングする}
+\addtocounter{Exercise}{-1}\refstepcounter{Exercise}\label{E:TV}
 考え方
 
 まずは、ウェブブラウザでTV番組表のページを見てみよう。
@@ -2135,16 +2154,19 @@ F5を押して実行してみましょう。
 \bigskip
 
 \subsection*{}
-\subsection*{問題8-21}
+\refstepcounter{Question}
+\subsection*{\theQuestion}
 \ \ 6行目のword=”サザエさん”で検索する番組を指定しています。
 自分の検索したい番組名にして実行してみましょう。
 
-\subsection*{問題8-22}
+\refstepcounter{Question}
+\subsection*{\theQuestion}
 \ \ このプログラムでは、日付(date配列)と番組名(ptitle配列)しか表示をしていません。
 ジャンル(genre配列)とテレビ局(station配列)を表示するようにしてみましょう。
 
-\clearpage\subsection*{問題8-23
-Weblioのウェブページをスクレイピングする}
+\refstepcounter{Exercise}
+\clearpage\subsection*{\theExercise　Weblioのウェブページをスクレイピングする}
+\addtocounter{Exercise}{-1}\refstepcounter{Exercise}\label{E:Weblio}
 考え方
 
 まずは、ウェブブラウザでWeblioのページを見てみよう。
@@ -2255,7 +2277,8 @@ F5を押して実行してみましょう。
 \includegraphics[width=17.006cm,height=8.698cm]{textbook-img046.png}
 
 \end{center}
-\subsection*{問題8-24}
+\refstepcounter{Question}
+\subsection*{\theQuestion}
 7行目のword=”hello”で検索する英語を指定しています。
 この変数を自分の検索したい英語にして実行してみましょう。
 
@@ -2264,8 +2287,9 @@ F5を押して実行してみましょう。
 
 \bigskip
 
-\clearpage\subsection*{問題8-25
-位置情報のから近くの駅をスクレイピング}
+\refstepcounter{Exercise}
+\clearpage\subsection*{\theExercise　位置情報のから近くの駅をスクレイピング}
+\addtocounter{Exercise}{-1}\refstepcounter{Exercise}\label{E:station}
 考え方
 
 まずは、ウェブブラウザで駅検索API情報のページを見てみよう。
@@ -2360,7 +2384,8 @@ F5を押して実行してみましょう。実行結果はターミナルに表
 \includegraphics[width=11.409cm,height=9.795cm]{textbook-img052.png}
 
 \end{center}
-\clearpage\subsection*{問題 8-26}
+\refstepcounter{Question}
+\clearpage\subsection*{\theQuestion}
 \ \ サンプルプログラムでは、青梅市役所の近くの駅名を取得していました。
 次は、自分の好きなもしくは知っている場所を指定してみましょう。
 緯度経度は、授業で使用したウェブページ\textbf{(\~{}/ome/08/links.html)}を開いて、
@@ -2436,8 +2461,9 @@ keido=”139.27542”
 
 \bigskip
 
-\clearpage\subsection*{問題8-27
-郵便番号から住所を調べるウェブページのスクレイピング}
+\refstepcounter{Exercise}
+\clearpage\subsection*{\theExercise　郵便番号から住所を調べるウェブページのスクレイピング}
+\addtocounter{Exercise}{-1}\refstepcounter{Exercise}\label{E:postNum}
 考え方
 
 まずは、ウェブブラウザで郵便番号から住所を調べるウェブページを見てみよう。
@@ -2528,7 +2554,8 @@ F5を押して実行してみましょう。実行結果はターミナルに表
 
 
 
-\subsection*{問題8-28}
+\refstepcounter{Question}
+\subsection*{\theQuestion}
 \ \ codeの郵便番号を変更してみよう
 
 \ \ 例: 198-0082
@@ -2541,7 +2568,9 @@ F5を押して実行してみましょう。実行結果はターミナルに表
 \end{enumerate}
 \end{boxedminipage}
 \end{center}
-\clearpage\subsection*{問題8-29 Wikipediaのスクレイピング}
+\refstepcounter{Exercise}
+\clearpage\subsection*{\theExercise　Wikipediaのスクレイピング}
+\addtocounter{Exercise}{-1}\refstepcounter{Exercise}\label{E:wikipedia}
 考え方
 
 まずは、ウェブブラウザでWikipediaを見てみよう。
@@ -2651,7 +2680,8 @@ Pi)の概要がWikipediaからとれました。
 
 \bigskip
 
-\subsection*{問題8-30}
+\refstepcounter{Question}
+\subsection*{\theQuestion}
 wordを自分の検索したい単語に変えてみよう。
 
 \ \ HINT:まずは、Wikipediaで検索したい単語を検索をしてみて、ページを開きましょう。
@@ -2721,30 +2751,30 @@ word = “フランシスコ・ザビエル”
 \begin{supertabular}{|m{6.7730002cm}|m{2.042cm}|m{7.5810003cm}|}
 \hline
 ファイルの場所 &
-例題、問題 &
+例題 &
 機能説明\\\hline
 	\textbf{\~{}/ome/08/tv.hsp} &
-問題8-20 &
+\ref*{E:TV} &
 TVの番組表で検索をして次に放送される番組１つを取得して表示するプログラム
 
 スクリプトエディタで読み込んで、F5で実行\\\hline
 	\textbf{\~{}/ome/08/weblio.hsp} &
-問題8-23 &
+\ref*{E:Weblio} &
 英単語を辞書で検索して、日本語訳を表示するプログラム
 
 スクリプトエディタで読み込んで、F5で実行\\\hline
 	\textbf{\~{}/ome/08/eki.hsp} &
-問題8-25 &
+\ref*{E:station} &
 最寄り駅とその路線情報を取得して表示するプログラム
 
 スクリプトエディタで読み込んで、F5で実行\\\hline
 	\textbf{\~{}/ome/08/zipcode.hsp} &
-問題8-27 &
+\ref*{E:postNum} &
 郵便番号から住所を検索するプログラム
 
 スクリプトエディタで読み込んで、F5で実行\\\hline
 	\textbf{\~{}/ome/08/wikipedia.hsp} &
-問題8-29 &
+\ref*{E:wikipedia} &
 ウィキペディアで用語を検索して、最初の数行を表示するプログラム
 
 スクリプトエディタで読み込んで、F5で実行\\\hline

--- a/08/text08.tex
+++ b/08/text08.tex
@@ -22,6 +22,10 @@
 {./text08-img/}%
 }
 
+\newcounter{Exercise}
+\newcounter{Question}
+\renewcommand\theExercise{例題 8-\arabic{Exercise}}
+\renewcommand\theQuestion{\textbf{問題 8-\arabic{Question}}}
 % Outline numbering
 \setcounter{secnumdepth}{3}
 \renewcommand\thesection{\arabic{section}}
@@ -299,8 +303,9 @@ IPアドレス:ポート
 
 \bigskip
 
-\clearpage\section{例題8-1
-コマンドラインからウェブページをダウンロードする}
+\refstepcounter{Exercise}
+\clearpage\section{\theExercise　コマンドラインからウェブページをダウンロードする}
+\addtocounter{Exercise}{-1}\refstepcounter{Exercise}\label{E:CURL}
 インターネットから情報を取ってくるときに使用するツールは
 curl (カール)と言います。 curl
 はデータを送ったり受け取ったりするときに使います。
@@ -402,11 +407,12 @@ leafpadを使ってダウンロードしたHTMLファイルを開いて友達の
 \ \ \ \ Hint :
 ダウンロードしたファイルをleafpadで見てみよう
 
-\clearpage\section{例題8-2
-ダウンロードしたページを調べてみましょう}
+\refstepcounter{Exercise}
+\clearpage\section{\theExercise　ダウンロードしたページを調べてみましょう}
+\addtocounter{Exercise}{-1}\refstepcounter{Exercise}\label{E:HTML}
 考え方
 
-例題8-1で、友達のウェブページのHTMLをダウンロードしました。次はほしい情報を取り出します。ここでは、テキストエディタで検索をして、ほしい情報を探し抜き出します。
+\ref*{E:CURL}で、友達のウェブページのHTMLをダウンロードしました。次はほしい情報を取り出します。ここでは、テキストエディタで検索をして、ほしい情報を探し抜き出します。
 
 コマンドラインを開いて
 
@@ -474,7 +480,7 @@ leafpad
 
 {\bfseries
 注意 :
-{\textless}title{\textgreater}は半角文字です。入力モードが半角になっているか確認してください。(詳しくは例題1-4を見てください)}
+{\textless}title{\textgreater}は半角文字です。入力モードが半角になっているか確認してください。}
 
 
 \begin{center}
@@ -488,8 +494,9 @@ leafpad
 \bigskip
 
 毎回手動で友達のウェブページをダウンロードして、検索して探すのは大変です。次はプログラムから自動で行う方法を学びましょう。
-
-\clearpage\section{例題8-3 HSPから情報を取り出す}
+\refstepcounter{Exercise}
+\clearpage\section{\theExercise　HSPから情報を取り出す}
+\addtocounter{Exercise}{-1}\refstepcounter{Exercise}\label{E:SCRAPING}
 考え方
 
 前の例題でやったように、毎回手動で友達のウェブページをダウンロードして、テキストエディタを使って検索するのは大変です。
@@ -848,9 +855,8 @@ ASCIIでは0〜127を使用していました。
 \end{itemize}
 
 \bigskip
-
-\clearpage\section{例題8-4
-数字をASCIIを使って文字に変える}
+\refstepcounter{Exercise}
+\clearpage\section{\theExercise　数字をASCIIを使って文字に変える}
 考え方
 
 \ \ printfコマンドを使用すると数字をASCIIに従って文字へ変換できます。
@@ -920,9 +926,9 @@ Char(Character)は文字を意味します。}
 \end{center}
 {\bfseries
 [\url{https://simple.wikipedia.org/wiki/ASCII}]}
-
-\clearpage\section{例題8-5
-数字をUTF-8を使って文字に変える}
+\refstepcounter{Exercise}
+\clearpage\section{\theExercise　数字をUTF-8を使って文字に変える}
+\addtocounter{Exercise}{-1}\refstepcounter{Exercise}\label{E:UTF8}
 考え方
 
 \ \ printfコマンドを使用すると数字をUTF-8に従って文字に変換できます。
@@ -997,9 +1003,8 @@ UTF-8を使ってひらがなでとなりの友達の名前を表示させてみ
 \bigskip
 
 [\url{http://orange-factory.com/sample/utf8/code3/e3.html#Hiragana}]
-
-\clearpage\section{例題8-6
-ウェブページで使用されている文字コードを変換する}
+\refstepcounter{Exercise}
+\clearpage\section{\theExercise　ウェブページで使用されている文字コードを変換する}
 考え方
 
 ある文字コードで表現された文字列を他の文字コードで解釈すると文字化けをする可能性があります。
@@ -1201,13 +1206,9 @@ charset=””{\textgreater}を変換後の文字コードに変更するのを�
 \clearpage\section{スクレイピング}
 クレイピングとは、ウェブページから情報を取り出すことをいいます。
 スクレイピングの手順はウェブページをダウンロードして、ウェブページから欲しい情報を探して取り出し、そして、取り出し情報を加工します。
-例題8-1,
-8-2%
-%例題番号UPDATE
-%koyaman 
-%September 24, 2019 4:28 PM
+\ref*{E:CURL},\ref*{E:HTML}
 で手動でウェブページをダウンロードして、そこから情報を取り出しました。
-そのあとの例題8-3では、同じ手順をプログラムで自動で行いました。
+そのあとの\ref*{E:SCRAPING}では、同じ手順をプログラムで自動で行いました。
 ウェブページから取り出した情報をプログラムから有効的に使う方法を学びましょう。
 ウェブページから取り出した情報をもとにセンサーを使ったり、情報をウェブページに反映することもできます。
 ウェブページから価値のある情報を取り出して、今まで習った技術と組み合わせて役に立つプログラムを作れるように考えながら例題を進めていきましょう。
@@ -1215,8 +1216,8 @@ charset=””{\textgreater}を変換後の文字コードに変更するのを�
 
 
 \bigskip
-
-\clearpage\section{例題8-7アメダスのウェブページをスクレイピングする}
+\refstepcounter{Exercise}
+\clearpage\section{\theExercise　アメダスのウェブページをスクレイピングする}
 %\newline
 考え方
 
@@ -1538,7 +1539,7 @@ kionが25.0度以上のときに、現在の気温を表示し、センサーボ
 \bigskip
 
 \clearpage\section{スクレイピングの仕組み}
-例題8-3でHSPのプログラムから友達のウェブページのタイトルを取り出したように、スクレイピングでは、HTMLファイルのタグ(例題8-3では{\textless}title{\textgreater}{\textless}/title{\textgreater})を探します。
+\ref*{E:SCRAPING}でHSPのプログラムから友達のウェブページのタイトルを取り出したように、スクレイピングでは、HTMLファイルのタグ(\ref*{E:SCRAPING}では{\textless}title{\textgreater}{\textless}/title{\textgreater})を探します。
 しかし、ウェブページの欲しい情報はHTMLファイル内のどのタグで作られているでしょうか？ウェブページをダウンロードして、HTMLファイルを眺めても探しても良いのですが、かなり大変です。
 ここでは、ウェブページの欲しい情報がどのHTMLファイル内のどのタグで作られているか調べる方法としてブラウザの検証ツールを使った方法を紹介します。
 アメダスのウェブページを例に試していきます。
@@ -1631,7 +1632,6 @@ data,
 
 表は{\textless}table{\textgreater}{\textless}/table{\textgreater}タグ(table,
 表)で作りました。
-(詳しくは1回目のテキストの例題1-19に説明があります。）
 
 
 アメダスのサイトから情報を取り出す際には、まずは、{\textless}table{\textgreater}{\textless}/table{\textgreater}タグを探して取り出します。
@@ -1665,8 +1665,8 @@ classはいわば名前のようなもので、このタグについている情
 
 
 \bigskip
-
-\clearpage\section{応用例題8-1 amedas.pyをlessで見てみよう}
+\refstepcounter{Exercise}
+\clearpage\section{\theExercise　amedas.pyをlessで見てみよう}
 「スクレイピングの仕組み」では、アメダスのウェブページからアメダス観測値を取得する流れを解説しました。
 実際にウェブページから値を取り出すのに使用しているコマンド(プログラム)を見てみましょう。
 amedas.pyコマンドはHSPのプログラムから呼び出しているものです。
@@ -1799,9 +1799,8 @@ amedas-table-entries{\textquotedbl}{\textgreater} ... {\textless}/table{\textgre
 次は、スクレイピングを習った技術と組み合わせることを学びます。
 スクレイピングだけでも、かなりできることは広がりますが、やはりセンサーボードやJulius、OpenJtalkなど習った技術と組み合わせるとさらに便利で楽しいものが作れます。
 
-
-\clearpage\section{例題 8-8
-スクレイピングした情報をもとにセンサーを使う}
+\refstepcounter{Exercise}
+\clearpage\section{\theExercise　スクレイピングした情報をもとにセンサーを使う}
 スクレイピングで得た情報を習った技術(センサーボードの使い方、OpenJtalk,
 Juliusなど)と組み合わせて便利なことや楽しいことをする練習をしましょう。
 この例では、アメダスのウェブページから取得した気温を使って暑いか涼しいかを判断してLEDで通知してくれるプログラムを試します。
@@ -1894,7 +1893,7 @@ LEDに注目すると、暑いときには緑色のLED、涼しいときはオ�
 
 \bigskip
 
-7行目までは例題8-5と基本的に同じです。
+7行目までは\ref*{E:UTF8}と基本的に同じです。
 
 8〜18行目で、温度をもとに暑いか、涼しいかメッセージを表示させてLEDを点灯させています。
 


### PR DESCRIPTION
closes #290
closes #348 
### 第７回
- #148 のカウンタ設定マクロを用いて第７，８回の例題と問題にカウンタを設定した。また、例題設定以後に例題番号を参照するものはラベリングした。
### 第８回
- 上記と同様にカウンタ、ラベルを設定した。
- 問題8-20,23,25,27,29 -> 例題8-10,11,12,13,14