### PR TITLE
第5回のスライドとテキストの微修正

### DIFF
--- a/05/contents/chap05_03_3.tex
+++ b/05/contents/chap05_03_3.tex
@@ -29,12 +29,12 @@
 	goto *digital_off
         
 *digital_on
-	gpio 17, 1
+	gpio 23, 1
 	wait 10
 	goto *main
 
 *digital_off
-	gpio 17, 0
+	gpio 23, 0
 	wait 10
 	goto *main
 \end{lstlisting}

--- a/05/contents/chap05_03_4.tex
+++ b/05/contents/chap05_03_4.tex
@@ -1,6 +1,6 @@
 \newpage
 \section{アナログ入力\ruby{装置}{そう|ち}を使ってみよう}
-デジタル入力装置をHSPで使ってみましょう。GPIO24にボタン(\#103)をつけてください。HSPスクリプトエディタで\textasciitilde /05/anain.hspを開いて実行してみましょう。\\
+アナログ入力装置をHSPで使ってみましょう。A0に感圧センサー(\#106)をつけてください。
 \begin{figure}[H]
     \centering
     \includegraphics[scale=0.6]{images/chap05/text05-img030.png}

--- a/05/contents/chap05_03_4.tex
+++ b/05/contents/chap05_03_4.tex
@@ -1,6 +1,6 @@
 \newpage
 \section{アナログ入力\ruby{装置}{そう|ち}を使ってみよう}
-アナログ入力装置をHSPで使ってみましょう。A0に感圧センサー(\#106)をつけてください。
+アナログ入力装置をHSPで使ってみましょう。A0に感圧センサー(\#106)をつけてください。HSPスクリプトエディタで\textasciitilde /05/anain.hspを開いて実行してみましょう。\\
 \begin{figure}[H]
     \centering
     \includegraphics[scale=0.6]{images/chap05/text05-img030.png}

--- a/05/slide_contents/digital_input_device.tex
+++ b/05/slide_contents/digital_input_device.tex
@@ -55,7 +55,7 @@
 \begin{frame}
     \frametitle{センサーをピンにつけてみよう}
     \begin{center}
-        \includegraphics[width=0.8\textwidth]{images/chap05/text05-img029.png}
+        \includegraphics[width=0.7\textwidth]{images/chap05/text05-img029.png}
         \begin{itemize}
             \item GPIO23とLEDをつなげてみよう
             \item GPIO24と入力センサをつなげてみよう
@@ -79,12 +79,12 @@
 	goto *digital_off
         
 *digital_on
-	gpio 17, 1
+	gpio 23, 1
 	wait 10
 	goto *main
 
 *digital_off
-	gpio 17, 0
+	gpio 23, 0
 	wait 10
 	goto *main 
 \end{lstlisting}

--- a/05/slide_contents/digital_input_device.tex
+++ b/05/slide_contents/digital_input_device.tex
@@ -31,7 +31,7 @@
 \begin{frame}
     \frametitle{スイッチ}
     \begin{center}
-        \includegraphics[width=0.4\textwidth]{images/chap05/text05-img020.jpg}
+        \includegraphics[width=0.4\textwidth]{images/chap05/text05-img019.jpg}
         \begin{itemize}
             \item スイッチがオンのとき値が1になる
             \item スイッチがオフのとき値が0になる
@@ -43,7 +43,7 @@
 \begin{frame}
     \frametitle{リミットスイッチ}
     \begin{center}
-        \includegraphics[width=0.4\textwidth]{images/chap05/text05-img019.jpg}
+        \includegraphics[width=0.4\textwidth]{images/chap05/text05-img020.jpg}
         \begin{itemize}
             \item スイッチが押されたとき値が1になる
             \item スイッチが押されていいないとき値が0になる

--- a/05/slide_contents/ir.tex
+++ b/05/slide_contents/ir.tex
@@ -166,7 +166,7 @@ end remote
         \begin{itemize}
             \item 設定ファイルをコピー
         \end{itemize}
-        \item sudo service lidrcd restart
+        \item sudo service lircd restart
         \begin{itemize}
             \item 設定ファイルが再読み込みされる
         \end{itemize}

--- a/05/slide_contents/ir.tex
+++ b/05/slide_contents/ir.tex
@@ -302,7 +302,7 @@ sudo service lircd restart
     教科書32ページ 問題 5-14
     \begin{itemize}
         \item 自分の家にある家電をRaspberry Piで制御してみましょう。
-        \item エアコン、風船機、テレビなど赤外線を使って操作する家電を選びましょう。
+        \item エアコン、扇風機、テレビなど赤外線を使って操作する家電を選びましょう。
         \item 赤外線で動かない家電もあります。宿題の結果が動かなかった、でもOKです。
         \item 1問
     \end{itemize}


### PR DESCRIPTION
修正内容
- スライドの入れ替わっていたスイッチとリミットスイッチの画像を正す
- テキストとスライドのdigin.hspのLEDのGPIO番号を17から23にする (#355 )
- テキストの「 アナログ入力装置を使ってみよう」の説明文の修正
- スライドのlircdコマンドのタイポを修正
- スライドの「風船機」を「扇風機」に修正