### PR TITLE
第8回スライド minor fix

### DIFF
--- a/08/slide08-2.tex
+++ b/08/slide08-2.tex
@@ -53,7 +53,7 @@
 
 \begin{frame}[fragile]
 	\frametitle{文字コードについて知ろう:テキスト P.\pageref{1:P:charCode}-P.\pageref{1:P:scraping}~~~\raisebox{-3mm}{\includegraphics[width=0.1\textwidth]{raspberry}}}
-    \large\textbf{P.XのASCIIコード表を見てみましょう}\\
+    \large\textbf{P.\pageref{1:P:charCode}のASCIIコード表を見てみましょう}\\
     \begin{minipage}{0.55\textwidth}
         \begin{itemize}
             \item Decimalは10進数の数字、Hex(Hexadecimal)は16進数の数字、Char(Character)は文字を表します。


### PR DESCRIPTION
2時間目のスライドのasciiコード表の参照をつけ忘れていたのを修正

[slide08-2.pdf](https://github.com/OmeSatoFoundation/ome-doc/files/12668656/slide08-2.pdf)

### 修正前

![image](https://github.com/OmeSatoFoundation/ome-doc/assets/78594153/16d4c45a-efb0-4e62-b87c-8766cd359997)

### 修正後
![image](https://github.com/OmeSatoFoundation/ome-doc/assets/78594153/28c020e9-0e74-4439-90d2-c312cf839ffd)
