### PR TITLE
［第6回］リスト6.8 文字訂正(Fix #358)

### DIFF
--- a/06/contents/chap06_05_5.tex
+++ b/06/contents/chap06_05_5.tex
@@ -7,7 +7,7 @@ ON おん
 OFF おふ
 \end{lstlisting}
 
-\begin{lstlisting}[caption=ledvoice.hsp,label=ledvoice.hsp]
+\begin{lstlisting}[caption=ledbyvoice.hsp,label=ledbyvoice.hsp]
 #include "hsp3dish.as"
 #include "julius.as"
 


### PR DESCRIPTION
リスト6.8のcaptionが`ledvoice.hsp`となっていたのを`ledbyvoice.hsp`と修正した。