### PR TITLE
Fix the version of 2023 for texlive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,9 +84,9 @@ RUN cd ~/ \
 
 WORKDIR /install-tl-unx
 COPY ./prod/texlive.profile ./
-RUN wget -nv https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+RUN wget -nv https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2023/install-tl-unx.tar.gz
 RUN tar -xzf ./install-tl-unx.tar.gz --strip-components=1
-RUN perl ./install-tl --scheme=full --no-doc-install --no-src-install --no-interaction
+RUN perl ./install-tl --scheme=full --no-doc-install --no-src-install --no-interaction --repository https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2023/tlnet-final/
 RUN ln -sf /usr/local/texlive/*/bin/* /usr/local/bin/texlive
 RUN tlmgr install \
   collection-fontsrecommended \


### PR DESCRIPTION
Current Dockerfile fetches the latest of texlive and does not replicate typeset environments at that time; in that case `lualatex` causes an error related to `\setmainjfont`:

```
PS G:\ome-doc> docker run --rm -v ${pwd}:/workdir -ti ome-doc sh -c 'cd 03 ; llmk'

(Omitted)

(/usr/local/texlive/2024/texmf-dist/tex/luatex/luatexja/addons/luatexja-fontspe
c-27c.sty))
! Undefined control sequence.
\__ltj_fontspec_setup_single_size:nnn ...nown:nxN
                                                  {fontspec-sizing}{\exp_aft...

l.27 \setmainjfont
                [Ligatures={Common,TeX},
? X
 733 words of node memory still in use:
   6 hlist, 4 rule, 1 dir, 3 kern, 1 glyph, 116 attribute, 49 glue_spec, 18 att
ribute_list, 1 if_stack, 1 write, 8 user_defined nodes
   avail lists: 1:4,2:121,3:3,4:4,5:2,6:1,7:7,9:8

warning  (pdf backend): no pages of output.
Transcript written on text03.log.
llmk error: Fail running lualatex --shell-escape --cnf-line='TEXINPUTS=.;../texmf//;' "text03.tex" (exit code: 1)
```

where texlive fetched on 2024-05-06, windows 10 Powershell 7.4.2, Docker version 26.0.0, build 2ae903e.