### PR TITLE
【第3回】リスト3.19から3.43の修正

### DIFF
--- a/03/contents/chap03_310_AdvancedCommands.tex
+++ b/03/contents/chap03_310_AdvancedCommands.tex
@@ -89,7 +89,7 @@
 次に、具体的な例を見てみましょう。
 \begin{lstlisting}[caption=wcコマンドの実行例, label=wc_example]
 <#green#pi@raspberrypi#>:<#blue#~ $#> wc ~/03/rensyu/kokugo/syosetsu.txt
-13 13 93 /home/pi/lsfile
+  118    99 16061 /home/pi/03/rensyu/kokugo/syousetu.txt
 \end{lstlisting}
 この例では、\textasciitilde/lsfileの中身の文字数・単語数・行数を表示しています。
 左から順に、行数、単語数、文字数、ファイルのパスを表しています。
@@ -102,13 +102,13 @@
 \end{description}
 例として、1から5までの数字をseqで表示してみましょう。
 \begin{lstlisting}[caption=seqコマンド]
-<#green#pi@raspberrypi#>:<#blue#~/03/rensyu/xargs $#> seq 1 5
+<#green#pi@raspberrypi#>:<#blue#~ $#> seq 1 5
 1
 2
 3
 4
 5
-<#green#pi@raspberrypi#>:<#blue#~/03/rensyu/xargs $#>
+<#green#pi@raspberrypi#>:<#blue#~ $#>
 \end{lstlisting}
 seqコマンドを使うことで、数字を\ruby{順番}{じゅん|ばん}に出力することができました。
 
@@ -120,9 +120,9 @@ seqコマンドを使うことで、数字を\ruby{順番}{じゅん|ばん}に�
 \end{description}
 
 \begin{lstlisting}[caption=echoコマンド]
-<#green#pi@raspberrypi#>:<#blue#~/03/rensyu/xargs $#> echo hello
+<#green#pi@raspberrypi#>:<#blue#~ $#> echo hello
 hello
-<#green#pi@raspberrypi#>:<#blue#~/03/rensyu/xargs $#>
+<#green#pi@raspberrypi#>:<#blue#~ $#>
 \end{lstlisting}
 echoコマンドを使うことでhelloと出力できました。
 
@@ -135,13 +135,13 @@ echoコマンドを使うことでhelloと出力できました。
     \item[● \texttt{touch} \underline{ファイル名}$\cdots$]\mbox{}\\
     名前が\underline{ファイル名}$\cdots$の空のファイルを作成します。ファイルがすでにある場合は、ファイルの更新日時とアクセス日時を更新します。 
 \end{description}
-　ファイルの更新日時とアクセス日時とは、それぞれ最後にファイルを保存した日時と、最後にファイルを読んだ日時になります。 ls -a で確認することができます。
+　ファイルの更新日時とアクセス日時とは、それぞれ最後にファイルを保存した日時と、最後にファイルを読んだ日時になります。 ls -l で確認することができます。
 
 \begin{lstlisting}[caption=空のファイルを作成, label=cmd:touch]
-    <#green#pi@raspberrypi#>:<#blue#~ $#> touch testtouch
-    <#green#pi@raspberrypi#>:<#blue#~ $#> ls -a testtouch
-    -rw-r--r-- 1 okuyama okuyama 0 Jul  8 13:05 testtouch <- 7月8日13:05に更新された。
-    ↑ラズパイの実行結果に合わせる
+<#green#pi@raspberrypi#>:<#blue#~ $#> touch testtouch
+<#green#pi@raspberrypi#>:<#blue#~ $#> ls -l testtouch
+-rw-r--r-- 1 pi pi 0  7月 11 19:40 testtouch <- 7月11日19:40に更新された。
+↑ラズパイの実行結果に合わせる
 \end{lstlisting}
 
 \begin{tcolorbox}[title=\useOmetoi]
@@ -213,6 +213,7 @@ Public
 Templates
 Videos
 lsfile
+testtouch
 \end{lstlisting}
 
 「>(大なり記号)」の後にファイル名を指定することで、
@@ -236,6 +237,7 @@ Public
 Templates
 Videos
 lsfile
+testtouch
 \end{lstlisting}
 
 ちなみに、"cat lsfile"と入力しても動作は同じです。
@@ -255,6 +257,9 @@ lsfile
 
 \begin{lstlisting}[caption=lsコマンドの出力をパイプでlessコマンドに渡す, label=redirectCat]
 <#green#pi@raspberrypi#>:<#blue#~ $#> ls | less
+\end{lstlisting}
+
+\begin{lstlisting}[caption=lsコマンドの出力をパイプでlessコマンドに渡した結果, label=redirectCat_result]
 01
 02
 03
@@ -268,6 +273,13 @@ Public
 Templates
 Videos
 lsfile
+testtouch
+~
+~
+~
+~
+~
+(END)
 \end{lstlisting}
 
 lsコマンドはリダイレクトやパイプを使うとファイルが一行ずつ出力されます。
@@ -309,6 +321,7 @@ lessコマンドにlsコマンドの\ruby{標準}{ひょう|じゅん}出力を�
 次に、具体的な例を見てみましょう
 \begin{lstlisting}[caption=tacコマンドの実行例, label=tac_example]
 <#green#pi@raspberrypi#>:<#blue#~ $#> tac ~/lsfile
+testtouch
 lsfile
 Videos
 Templates
@@ -343,6 +356,7 @@ Music
 01
 Videos
 Pictures
+testtouch
 Bookshelf
 Templates
 Public
@@ -373,8 +387,8 @@ Downloads
 次に、具体的な例を見てみましょう。
 \begin{lstlisting}[caption=tailコマンドの実行例, label=shuf_example]
 <#green#pi@raspberrypi#>:<#blue#~ $#> tail -n 2 ~/lsfile
-Videos
 lsfile
+testtouch
 \end{lstlisting}
 この例では、lsfileの中身の末尾の2行を表示しました。
 
@@ -394,12 +408,13 @@ Bookshelf
 Desktop
 Documents
 Downloads
-lsfile
 Music
 Pictures
 Public
 Templates
 Videos
+lsfile
+testtouch
 \end{lstlisting}
 この例では、lsfileの中身を順番に並べ替えて表示してみました。
 数字とアルファベットが\ruby{混在}{こん|ざい}している場合、数字が先に表示され、その後にアルファベットが表示されます。
@@ -437,7 +452,7 @@ Videos
 例えば、lsコマンドの標準出力をフィルタコマンドであるsortに渡すことで、ファイルの\ruby{一覧}{いち|らん}を並び替える方法を紹介します。
 
 \begin{lstlisting}[caption=パイプラインを用いたsortコマンドの実行例, label=sort_example]
-<#green#pi@raspberrypi#>:<#blue#~ $#> ls ~/03 | sort
+<#green#pi@raspberrypi#>:<#blue#~ $#> ls | sort
 01
 02
 03
@@ -445,15 +460,16 @@ Bookshelf
 Desktop
 Documents
 Downloads
-lsfile
 Music
 Pictures
 Public
 Templates
 Videos
+lsfile
+testtouch
 \end{lstlisting}
 
-この例では、lsコマンドで\textasciitilde/03の中身を表示し、その結果をsortコマンドに渡して並べ替えています。
+この例では、lsコマンドでhomeディレクトリの中身を表示し、その結果をsortコマンドに渡して並べ替えています。
 lsfileをsortコマンドに渡した\ruby{際}{さい}と同じ結果が表示されていることが分かります。
 
 

--- a/03/contents/chap03_310_AdvancedCommands.tex
+++ b/03/contents/chap03_310_AdvancedCommands.tex
@@ -129,19 +129,18 @@ echoコマンドを使うことでhelloと出力できました。
 %%%%%%%%
 
 \subsection{\ruby{空}{から}のファイルを作成する}
-出力を作るコマンドではありませんが、\ruby{空}{から}のファイルを作成するコマンドを紹介ます。
+出力を作るコマンドではありませんが、\ruby{空}{から}のファイルを作成する便利なコマンドを紹介します。
 
 \begin{description}
     \item[● \texttt{touch} \underline{ファイル名}$\cdots$]\mbox{}\\
     名前が\underline{ファイル名}$\cdots$の空のファイルを作成します。ファイルがすでにある場合は、ファイルの更新日時とアクセス日時を更新します。 
 \end{description}
-　ファイルの更新日時とアクセス日時とは、それぞれ最後にファイルを保存した日時と、最後にファイルを読んだ日時になります。 ls -l で確認することができます。
 
+ファイルの更新日時とアクセス日時とは、それぞれ最後にファイルを保存した日時と、最後にファイルを読んだ日時になります。 ls -l で確認することができます。
 \begin{lstlisting}[caption=空のファイルを作成, label=cmd:touch]
 <#green#pi@raspberrypi#>:<#blue#~ $#> touch testtouch
 <#green#pi@raspberrypi#>:<#blue#~ $#> ls -l testtouch
 -rw-r--r-- 1 pi pi 0  7月 11 19:40 testtouch <- 7月11日19:40に更新された。
-↑ラズパイの実行結果に合わせる
 \end{lstlisting}
 
 \begin{tcolorbox}[title=\useOmetoi]


### PR DESCRIPTION
# 変更したコマンド
- wc: 結果を変更
- seq: 行するディレクトリをhomeに変更
- echo: 同上
- touch: lsのオプションを変更
- lsの出力をリダイレクトする: cat lsfileの出力結果の末尾にtesttouchを追加
- cat: コマンドにリダイレクトでファイルを入力する: cat < lsfile の出力結果の末尾にtesttouchを追加
- lsコマンドの出力をパイプでlessコマンドに渡す: リストを一つ追加し、lessの実行結果を記述
- tac: 出力結果の先頭にtesttouchを追加
- shuf: 出力結果にtesttouchを追加
- tail: 出力結果の先頭のVIdeoを削除し、末尾にtesttouchを追加
- sort: 実行結果の末尾にtesttouchを追加
- パイプラインを用いたsortコマンドの実行: 表示するディレクトリをhomeに変更

# 書式表現の変更
- touchの説明: ls のオプションをaからlに変更
- パイプラインを用いたsortコマンドの実行: 説明の~03をhomeディレクトリに変更