### PR TITLE
#565 の一部の修正

### DIFF
--- a/03/contents/chap03_110_Terminal.tex
+++ b/03/contents/chap03_110_Terminal.tex
@@ -22,8 +22,8 @@
 \subsection{この章で使うファイルをコピーしよう}
 はじめに、この章で使うファイルをコピーしてもらいます。コマンドの説明はあとで行いますので、以下のコマンドを入力して実行してみましょう。
 \begin{lstlisting}[caption=使うファイルのコピー,label=workfilecopy]
-  <#green#pi@raspberrypi#>:<#blue#~ $#> cp -r /usr/local/share/ome/03 ~
-  <#green#pi@raspberrypi#>:<#blue#~ $#>
+<#green#pi@raspberrypi#>:<#blue#~ $#> cp -r /usr/local/share/ome/03 ~
+<#green#pi@raspberrypi#>:<#blue#~ $#>
 \end{lstlisting}
 「\textasciitilde 」記号とスペースに気を付けて入力してください。不安な時はTAの先生に確認してもらってください。
 

--- a/03/contents/chap03_310_AdvancedCommands.tex
+++ b/03/contents/chap03_310_AdvancedCommands.tex
@@ -145,7 +145,7 @@ echoコマンドを使うことでhelloと出力できました。
 
 \begin{tcolorbox}[title=\useOmetoi]
     \begin{enumerate}
-        \addex{duコマンドを使って、\textasciitilde/02ディレクトリの大きさを表示してみましょう。}
+        \addex{duコマンドを使って、ホームディレクトリの大きさを表示してみましょう。}
         \addex{wcコマンドを使って、\textasciitilde/03/rensyu/kokugo/syosetsu.txtの中身の文字数・単語数・行数を表示してみましょう。}
         \addex{seqコマンドを使って、100から200までの数字を表示してみましょう。}
         \addex{echoコマンドを使って、I LOVE PROGRAMMING!と表示してみましょう。echoに空白を含む文字列をわたすときは、文字列を「'」で囲みましょう。}
@@ -468,7 +468,7 @@ lsfile
 testtouch
 \end{lstlisting}
 
-この例では、lsコマンドでhomeディレクトリの中身を表示し、その結果をsortコマンドに渡して並べ替えています。
+この例では、lsコマンドでホームディレクトリの中身を表示し、その結果をsortコマンドに渡して並べ替えています。
 lsfileをsortコマンドに渡した\ruby{際}{さい}と同じ結果が表示されていることが分かります。
 
 
@@ -479,8 +479,8 @@ lsfileをsortコマンドに渡した\ruby{際}{さい}と同じ結果が表示�
         \addex{\textasciitilde/03/rensyu/kokugo/syosetsu.txtの行をランダムに入れ替えて表示してみましょう。}
         \addex{\textasciitilde/03/rensyu/kokugo/syosetsu.txtの先頭の5行を表示してみましょう。}
         \addex{\textasciitilde/03/rensyu/kokugo/syosetsu.txtの末尾の5行を表示してみましょう。}
-        \addex{\textasciitilde/02ディレクトリの中のファイルとディレクトリのリストをsortコマンドを使って並べ替えて表示してみましょう。 \\ 
-        ヒント:まず、02の中身を表示するコマンドの出力をリダイレクトでファイルに書き込もう。次にsortコマンドを使ってファイルの中身を並べ替えよう。}
+        \addex{\textasciitilde/03ディレクトリの中のファイルとディレクトリのリストをsortコマンドを使って並べ替えて表示してみましょう。 \\ 
+        ヒント:まず、03の中身を表示するコマンドの出力をリダイレクトでファイルに書き込もう。次にsortコマンドを使ってファイルの中身を並べ替えよう。}
         \addex{\textasciitilde/03/rensyu/kokugo/syosetsu.txtの中身から"ごんぎつね"という文字列に一致する行を表示してみましょう。}
     \end{enumerate}
 \end{tcolorbox}


### PR DESCRIPTION
#565  について以下を修正
- p2, リスト3.1の先頭のスペースを削除
- p36, 問題3-11-1, 「~/02」から「ホームディレクトリ」に置き換え
- p44, 下から２行目,「home ディレクトリ」から「ホームディレクトリ」へ表現を統一
- p45, 問題3-13-5, 対象のディレクトリを02から03へ変更