### PR TITLE
第3回 授業スライド調整

### DIFF
--- a/03/images/chap03/directory_relation.svg
+++ b/03/images/chap03/directory_relation.svg
@@ -1,0 +1,370 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="129.74489mm"
+   height="136.68373mm"
+   viewBox="0 0 129.74489 136.68373"
+   version="1.1"
+   id="svg12"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="directory_relation.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview14"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="2.8934905"
+     inkscape:cx="179.19534"
+     inkscape:cy="57.197354"
+     inkscape:window-width="1920"
+     inkscape:window-height="1094"
+     inkscape:window-x="-11"
+     inkscape:window-y="-11"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <defs
+     id="defs9">
+    <marker
+       style="overflow:visible"
+       id="ArrowWide"
+       refX="0"
+       refY="0"
+       orient="auto-start-reverse"
+       inkscape:stockid="Wide arrow"
+       markerWidth="1"
+       markerHeight="1"
+       viewBox="0 0 1 1"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid">
+      <path
+         style="fill:none;stroke:context-stroke;stroke-width:1;stroke-linecap:butt"
+         d="M 3,-3 0,0 3,3"
+         transform="rotate(180,0.125,0)"
+         sodipodi:nodetypes="ccc"
+         id="path1" />
+    </marker>
+    <rect
+       x="160.01435"
+       y="87.092044"
+       width="243.99597"
+       height="81.562392"
+       id="rect9" />
+    <marker
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path10943" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Send"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Send"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path10949" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker11204"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path11202" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path10937" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Mend-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path10943-4" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Mend-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path10943-6" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Mend-1-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path10943-4-7" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker11638"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path11636" />
+    </marker>
+    <rect
+       x="160.01434"
+       y="87.092041"
+       width="223.25977"
+       height="50.803694"
+       id="rect9-0" />
+  </defs>
+  <g
+     inkscape:label="レイヤー 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-59.487154,-47.793377)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="レイヤー 2"
+     transform="translate(-59.487154,-47.793377)">
+    <g
+       id="g6"
+       transform="translate(-10.415724,2.3544874)">
+      <g
+         id="g407"
+         transform="matrix(0.36012134,0,0,0.35380669,-5.7721839,11.579182)">
+        <path
+           d="m 277.45398,120.46519 h -10.57056 l -2.16423,-3.78551 c -0.53916,-0.94542 -1.54913,-1.53015 -2.63885,-1.53015 h -15.76091 c -1.04794,0 -1.89845,0.85051 -1.89845,1.89845 v 22.78138 c 0,1.04794 0.85051,1.89844 1.89845,1.89844 h 31.13455 c 1.04794,0 1.89845,-0.8505 1.89845,-1.89844 v -17.46573 c 0,-1.04794 -0.85051,-1.89844 -1.89845,-1.89844 z m -31.51424,-3.41721 c 0,-0.20883 0.17086,-0.37969 0.37969,-0.37969 h 15.76471 c 0.54296,0 1.04795,0.29236 1.31752,0.76697 l 1.73139,3.02993 h -19.19331 z m 31.89393,4.93596 v 18.2251 h -31.89393 v -18.2251 z"
+           id="path84"
+           style="stroke-width:0.0379687" />
+        <path
+           style="fill:#ffffff;stroke:#000000;stroke-width:0.365763"
+           d="m 245.97598,131.12623 v -8.96121 h 15.91072 15.91071 v 8.96121 8.96121 H 261.8867 245.97598 Z"
+           id="path246" />
+        <path
+           style="fill:#ffffff;stroke:#000000;stroke-width:0.365763"
+           d="m 246.04738,118.59883 0.11148,-1.73738 7.49816,-0.10359 c 4.12398,-0.057 7.86838,-0.0127 8.32089,0.0984 0.67813,0.16644 2.65201,2.61506 2.65201,3.28984 0,0.10458 -4.20615,0.19014 -9.34701,0.19014 h -9.34701 z"
+           id="path285" />
+      </g>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:3.52587px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.094443"
+         x="86.845207"
+         y="59.617203"
+         id="text2565"
+         transform="scale(1.0088844,0.99119383)"><tspan
+           sodipodi:role="line"
+           id="tspan2563"
+           style="font-size:3.52587px;stroke-width:0.094443"
+           x="86.845207"
+           y="59.617203">/</tspan></text>
+    </g>
+    <g
+       id="g7"
+       transform="translate(-4.2636524,0.03787605)">
+      <g
+         id="g407-3"
+         transform="matrix(0.36012134,0,0,0.35380669,-5.7721839,26.331872)">
+        <path
+           d="m 277.45398,120.46519 h -10.57056 l -2.16423,-3.78551 c -0.53916,-0.94542 -1.54913,-1.53015 -2.63885,-1.53015 h -15.76091 c -1.04794,0 -1.89845,0.85051 -1.89845,1.89845 v 22.78138 c 0,1.04794 0.85051,1.89844 1.89845,1.89844 h 31.13455 c 1.04794,0 1.89845,-0.8505 1.89845,-1.89844 v -17.46573 c 0,-1.04794 -0.85051,-1.89844 -1.89845,-1.89844 z m -31.51424,-3.41721 c 0,-0.20883 0.17086,-0.37969 0.37969,-0.37969 h 15.76471 c 0.54296,0 1.04795,0.29236 1.31752,0.76697 l 1.73139,3.02993 h -19.19331 z m 31.89393,4.93596 v 18.2251 h -31.89393 v -18.2251 z"
+           id="path84-0"
+           style="stroke-width:0.0379687" />
+        <path
+           style="fill:#ffffff;stroke:#000000;stroke-width:0.365763"
+           d="m 245.97598,131.12623 v -8.96121 h 15.91072 15.91071 v 8.96121 8.96121 H 261.8867 245.97598 Z"
+           id="path246-3" />
+        <path
+           style="fill:#ffffff;stroke:#000000;stroke-width:0.365763"
+           d="m 246.04738,118.59883 0.11148,-1.73738 7.49816,-0.10359 c 4.12398,-0.057 7.86838,-0.0127 8.32089,0.0984 0.67813,0.16644 2.65201,2.61506 2.65201,3.28984 0,0.10458 -4.20615,0.19014 -9.34701,0.19014 h -9.34701 z"
+           id="path285-2" />
+      </g>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:3.52587px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.094443"
+         x="82.667305"
+         y="74.631516"
+         id="text3295"
+         transform="scale(1.0088844,0.99119383)"><tspan
+           sodipodi:role="line"
+           id="tspan3293"
+           style="font-size:3.52587px;stroke-width:0.094443"
+           x="82.667305"
+           y="74.631516">home</tspan></text>
+    </g>
+    <g
+       id="g8"
+       transform="translate(1.068143,-3.2956787)">
+      <g
+         id="g407-5"
+         transform="matrix(0.36012134,0,0,0.35380669,-5.7721839,42.249252)">
+        <path
+           d="m 277.45398,120.46519 h -10.57056 l -2.16423,-3.78551 c -0.53916,-0.94542 -1.54913,-1.53015 -2.63885,-1.53015 h -15.76091 c -1.04794,0 -1.89845,0.85051 -1.89845,1.89845 v 22.78138 c 0,1.04794 0.85051,1.89844 1.89845,1.89844 h 31.13455 c 1.04794,0 1.89845,-0.8505 1.89845,-1.89844 v -17.46573 c 0,-1.04794 -0.85051,-1.89844 -1.89845,-1.89844 z m -31.51424,-3.41721 c 0,-0.20883 0.17086,-0.37969 0.37969,-0.37969 h 15.76471 c 0.54296,0 1.04795,0.29236 1.31752,0.76697 l 1.73139,3.02993 h -19.19331 z m 31.89393,4.93596 v 18.2251 h -31.89393 v -18.2251 z"
+           id="path84-3"
+           style="stroke-width:0.0379687" />
+        <path
+           style="fill:#ffffff;stroke:#000000;stroke-width:0.365763"
+           d="m 245.97598,131.12623 v -8.96121 h 15.91072 15.91071 v 8.96121 8.96121 H 261.8867 245.97598 Z"
+           id="path246-7" />
+        <path
+           style="fill:#ffffff;stroke:#000000;stroke-width:0.365763"
+           d="m 246.04738,118.59883 0.11148,-1.73738 7.49816,-0.10359 c 4.12398,-0.057 7.86838,-0.0127 8.32089,0.0984 0.67813,0.16644 2.65201,2.61506 2.65201,3.28984 0,0.10458 -4.20615,0.19014 -9.34701,0.19014 h -9.34701 z"
+           id="path285-6" />
+      </g>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:3.52587px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.094443"
+         x="85.670174"
+         y="90.429184"
+         id="text3827"
+         transform="scale(1.0088844,0.99119383)"><tspan
+           sodipodi:role="line"
+           id="tspan3825"
+           style="font-size:3.52587px;stroke-width:0.094443"
+           x="85.670174"
+           y="90.429184">pi</tspan></text>
+    </g>
+    <path
+       style="opacity:0.98;fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:0.283718;stroke-linecap:square;stroke-dasharray:none;stroke-opacity:0.980392"
+       d="m 75.603723,63.91325 -0.04494,9.404965 2.404429,0.0599"
+       id="path8" />
+    <path
+       style="opacity:0.98;fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:0.325797;stroke-linecap:square;stroke-dasharray:none;stroke-opacity:0.980392"
+       d="m 80.124872,76.169001 -0.05953,9.362677 3.184841,0.05964"
+       id="path8-7" />
+    <rect
+       style="opacity:0.98;fill:#ff4a4a;fill-opacity:0.265421;stroke:#ff0000;stroke-width:0.431592;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.980392"
+       id="rect8"
+       width="14.629827"
+       height="11.331686"
+       x="76.933067"
+       y="66.229454" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,54.016388,43.230524)"
+       id="text8"
+       style="font-size:29.3333px;font-family:sans-serif;-inkscape-font-specification:sans-serif;white-space:pre;shape-inside:url(#rect9);display:inline;opacity:0.98;fill:#ff4a4a;fill-opacity:0.265421;stroke:#ff0000;stroke-width:0.755906;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.980392"><tspan
+         x="160.01367"
+         y="113.85346"
+         id="tspan4"><tspan
+   style="font-size:17.3333px;fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+   id="tspan1">注目</tspan><tspan
+   style="font-size:17.3333px;fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+   id="tspan2">する</tspan><tspan
+   style="font-size:17.3333px;fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+   id="tspan3">ディレクトリ</tspan> 
+</tspan></text>
+    <g
+       id="g1"
+       transform="matrix(0.96723789,0,0,1.0571631,27.697975,-22.017011)">
+      <text
+         xml:space="preserve"
+         transform="matrix(0.26458333,0,0,0.26458333,35.219107,52.19332)"
+         id="text8-8"
+         style="font-size:29.3333px;font-family:sans-serif;-inkscape-font-specification:sans-serif;white-space:pre;shape-inside:url(#rect9-0);display:inline;opacity:0.98;fill:#ff4a4a;fill-opacity:0.265421;stroke:#ff0000;stroke-width:0.755906;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.980392"><tspan
+           x="160.01367"
+           y="113.85346"
+           id="tspan9"><tspan
+   style="font-size:17.3333px;fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+   id="tspan5">上</tspan><tspan
+   style="font-size:17.3333px;fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+   id="tspan6">の</tspan><tspan
+   style="font-size:17.3333px;fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+   id="tspan7">ディレクトリ</tspan> 
+</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:4.5861px;font-family:sans-serif;-inkscape-font-specification:sans-serif;opacity:0.98;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.2;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+         x="78.357033"
+         y="98.727165"
+         id="text13"><tspan
+           sodipodi:role="line"
+           id="tspan13"
+           style="stroke-width:0.2;stroke-dasharray:none"
+           x="78.357033"
+           y="98.727165">下のディレクトリ</tspan></text>
+    </g>
+    <path
+       style="opacity:0.98;fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:0.319357;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#ArrowWide)"
+       d="m 92.503945,67.138623 7.717375,-0.05152 -0.0915,-7.272548 H 85.791374"
+       id="path11"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="opacity:0.98;fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:0.295283;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#ArrowWide)"
+       d="m 92.642844,76.416929 h 7.480866 l 0.0606,8.596737 -3.595718,-0.01894"
+       id="path13"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="レイヤー 3"
+     transform="translate(-59.487154,-47.793377)" />
+</svg>

--- a/03/slide03.tex
+++ b/03/slide03.tex
@@ -81,4 +81,5 @@
   \input slide_contents/title.tex
   \input slide_contents/shell_command.tex
   \input slide_contents/sensorboard.tex
+  \input slide_contents/advanced_command.tex
 \end{document}

--- a/03/slide_contents/advanced_command.tex
+++ b/03/slide_contents/advanced_command.tex
@@ -1,0 +1,646 @@
+\begin{frame}
+    \frametitle{出力を作るコマンド}
+    \begin{tabular}{ll}
+        コマンド & 動作                                         \\ \hline
+        ls       & ファイルやディレクトリを出力する             \\
+        du       & ディレクトリの中のファイルの大きさを報告する \\
+        wc       & 入力の文字数・単語数・行数を出力する         \\
+        echo     & 文字をそのまま出力する                       \\ \hline
+    \end{tabular}
+\end{frame}
+
+\begin{frame}
+    \frametitle{duコマンド}
+    du␣\underline{ファイルやディレクトリ}$\ldots$
+    \begin{itemize}
+        \item \underline{ファイルやディレクトリ}$\ldots$の大きさを表示するよ
+    \end{itemize}
+    duコマンドのオプション
+    \begin{itemize}
+        \item  -hオプション
+        \begin{itemize}
+            \item ディレクトリの大きさの数字に単位を付けるよ
+        \end{itemize}
+        \item -aオプション
+        \begin{itemize}
+            \item ディレクトリ内のファイルの大きさも表示するよ
+        \end{itemize}
+        \item -sオプション
+        \begin{itemize}
+            \item ディレクトリの大きさの合計のみを表示するよ
+        \end{itemize}
+    \end{itemize}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{wcコマンド}
+    wc␣\underline{ファイル}$\ldots$
+    \begin{itemize}
+        \item 指定した\underline{ファイル}$\ldots$の文字数・単語数・行数を表示するよ
+    \end{itemize}
+    \begin{lstlisting}[title=wcコマンドの実行例, label=wc_example]
+    <#green#pi@raspberrypi#>:<#blue#~ $#> wc ~/lsfile
+    13 13 93 /home/pi/lsfile
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{出力を作るコマンド}
+    seq␣\underline{数字1}␣\underline{数字2}
+    \begin{itemize}
+        \item \underline{数字1}から\underline{数字2}までの数字を順番に出力するよ
+        \begin{lstlisting}
+        <#green#pi@raspberrypi#>:<#blue#~/03/rensyu/xargs $#> seq 1 5
+        1
+        2
+        3
+        4
+        5
+        <#green#pi@raspberrypi#>:<#blue#~/03/rensyu/xargs $#>
+        \end{lstlisting}
+    \end{itemize}
+    echo␣\underline{文字列}$\ldots$
+    \begin{itemize}
+        \item \underline{文字列}$\ldots$をそのまま出力するよ
+        \begin{lstlisting}
+        <#green#pi@raspberrypi#>:<#blue#~/03/rensyu/xargs $#> echo hello
+        hello
+        <#green#pi@raspberrypi#>:<#blue#~/03/rensyu/xargs $#>
+        \end{lstlisting}
+    \end{itemize}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{空のファイルを作る}
+    touch \underline{ファイル名}$\ldots$
+    \begin{itemize}
+        \item 名前が\underline{ファイル名}$\ldots$の空のファイルを作るよ
+        \item ファイルがすでにある時はファイルの情報を更新するよ
+    \end{itemize}
+    \begin{lstlisting}[title=空のファイルを作成, label=cmd:touch]
+    <#green#pi@raspberrypi#>:<#blue#~ $#> touch testtouch
+    <#green#pi@raspberrypi#>:<#blue#~ $#> ls -l testtouch
+    -rw-r--r-- 1 pi pi 0  7月 11 19:40 testtouch <- 7月11日19:40に更新
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}
+    \frametitle{問題をといてみよう！}
+    \begin{itemize}
+        \item 教科書36ページ 問題3-11(5問)
+    \end{itemize}
+\end{frame}
+
+\begin{frame}
+    \frametitle{コマンドの入出力}
+    コマンドを実行すると３つのデータの通り道(チャネル)が準備されるよ
+    \begin{itemize}
+        \item 標準入力
+        \item 標準出力
+        \item 標準エラー出力
+    \end{itemize}
+    \begin{figure}[h]
+        \centering
+        \includesvg[width=0.8\columnwidth]{images/chap03/std_in_out_err.svg}
+    \end{figure}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{catコマンド}
+    \begin{itemize}
+        \item cat␣\underline{ファイル}$\ldots$
+        \begin{itemize}
+            \item \underline{ファイル}$\ldots$の中身を標準出力(ディスプレイ)に表示する
+        \end{itemize}
+        \item cat
+        \begin{itemize}
+            \item ファイルを指定しないと標準入力(キーボード)からデータを受け取るよ
+        \end{itemize}
+    \end{itemize}
+    \begin{lstlisting}[title=catの標準入力・標準出力, label=stdioCat]
+    <#green#pi@raspberrypi#>:<#blue#~ $#> cat 
+    sansu <Enter> <- 標準入力（キーボード）からの入力
+    sansu         <- 標準出力（ディスプレイ）への出力
+    <Ctrl+D>      <- 標準入力からEOFを入力し、入力が終了したことを伝える
+    <#green#pi@raspberrypi#>:<#blue#~ $#>
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}
+    \frametitle{リダイレクトってなんだろう？}
+    \begin{itemize}
+        \item 標準入力、標準出力、標準エラー出力の出力先をファイルに変更することだよ
+    \end{itemize}
+    \begin{figure}
+        \centering
+        \includesvg[width=0.7\linewidth]{images/chap03/redirect.svg}
+    \end{figure}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{リダイレクトの例}
+    \begin{lstlisting}[title=lsの出力をリダイレクトする, label=redirectLs]
+    <#green#pi@raspberrypi#>:<#blue#~ $#> ls 
+    <#blue#01  03         Desktop    Downloads  Pictures  Templates
+    02  Bookshelf  Documents  Music      Public    Videos#>
+    <#green#pi@raspberrypi#>:<#blue#~ $#> ls > lsfile
+    <#green#pi@raspberrypi#>:<#blue#~ $#> cat lsfile
+    01
+    02
+    03
+    Bookshelf
+    Desktop
+    Documents
+    Downloads
+    Music
+    Pictures
+    Public
+    Templates
+    Videos
+    lsfile
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}
+    \frametitle{パイプライン}
+    \begin{itemize}
+        \item パイプ（｜）を使って標準出力と標準入力をつなげることができるよ
+    \end{itemize}
+    \begin{figure}
+        \centering
+        \includesvg[width=1\linewidth]{images/chap03/pipe.svg}
+    \end{figure}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{パイプラインの例}
+    \begin{lstlisting}[title=lsコマンドの出力をパイプでlessコマンドに渡す, label=redirectCat]
+    <#green#pi@raspberrypi#>:<#blue#~ $#> ls | less
+    01
+    02
+    03
+    Bookshelf
+    Desktop
+    Documents
+    Downloads
+    Music
+    Pictures
+    Public
+    Templates
+    Videos
+    lsfile
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}
+    \frametitle{問題をといてみよう！}
+    \begin{itemize}
+        \item 教科書40ページ 問題3-12(3問)
+    \end{itemize}
+\end{frame}
+
+\begin{frame}
+    \frametitle{フィルタコマンド}
+    \begin{tabular}{ll}
+        コマンド & 動作                               \\ \hline
+        cat      & 入力をなにもせずに出力する         \\
+        tac      & 行を逆順に出力する                 \\
+        shuf     & 行をランダムに入れ替えて出力する   \\
+        head     & 先頭のいくつかの行を表示する       \\
+        tail     & 末尾のいくつかの行を表示する       \\
+        sort     & 行を順番にならべかえる             \\
+        grep     & 検索パターンに一致する行を出力する \\ \hline
+    \end{tabular}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{tacコマンド}
+    tac␣\underline{ファイル}$\ldots$
+    \begin{itemize}
+        \item \underline{ファイル}$\ldots$の内容を、行を逆順に出力するよ
+    \end{itemize}
+    \begin{lstlisting}[title=tacコマンドの実行例, label=tac_example]
+    <#green#pi@raspberrypi#>:<#blue#~ $#> tac ~/lsfile
+    lsfile
+    Videos
+    Templates
+    Public
+    Pictures
+    Music
+    Downloads
+    Documents
+    Desktop
+    Bookshelf
+    03
+    02
+    01 
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{shufコマンド}
+    shuf␣\underline{ファイル}$\ldots$
+    \begin{itemize}
+        \item \underline{ファイル}$\ldots$の内容、行をランダムに入れ替えて出力するよ
+    \end{itemize}
+    \begin{lstlisting}[title=shufコマンドの実行例, label=shuf_example]
+    <#green#pi@raspberrypi#>:<#blue#~ $#> shuf ~/lsfile
+    03
+    Desktop
+    Documents
+    02
+    Music
+    01
+    Videos
+    Pictures
+    Bookshelf
+    Templates
+    Public
+    lsfile
+    Downloads
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{headコマンド}
+    head␣-n␣\underline{行数}␣\underline{ファイル}$\ldots$
+    \begin{itemize}
+        \item \underline{ファイル}$\ldots$の内容を表示するよ
+        \item 先頭から指定した\underline{行数}分だけ表示されるよ
+    \end{itemize}
+    \begin{lstlisting}[title=headコマンドの実行例, label=shuf_example]
+    <#green#pi@raspberrypi#>:<#blue#~ $#> head ~/lsfile -n 2
+    01
+    02
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{tailコマンド}
+    tail␣-n␣\underline{行数}␣\underline{ファイル}$\ldots$
+    \begin{itemize}
+        \item \underline{ファイル}$\ldots$の内容を表示するよ
+        \item 末尾から指定した\underline{行数}分だけ表示されるよ
+    \end{itemize}
+    \begin{lstlisting}[title=tailコマンドの実行例, label=shuf_example]
+    <#green#pi@raspberrypi#>:<#blue#~ $#> tail ~/lsfile -n 2
+    Videos
+    lsfile
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{sortコマンド}
+    sort␣\underline{ファイル}$\ldots$
+    \begin{itemize}
+        \item \underline{ファイル}$\ldots$の内容を、行を辞書順に並べ替えるよ
+        \item ファイルの名前が数字のものが先に表示されるよ
+    \end{itemize}
+    \begin{lstlisting}[title=sortコマンドの実行例, label=sort_example]
+    <#green#pi@raspberrypi#>:<#blue#~ $#> sort ~/lsfile
+    01
+    02
+    03
+    Bookshelf
+    Desktop
+    Documents
+    Downloads
+    lsfile
+    Music
+    Pictures
+    Public
+    Templates
+    Videos
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{grepコマンド}
+    grep␣\underline{パターン}␣\underline{ファイル}$\ldots$
+    \begin{itemize}
+        \item \underline{ファイル}$\ldots$から\underline{パターン}に一致する行を表示するよ
+        \item 一致する文字列は赤字で表示されるよ
+        \item 一致する行がある場合はその行のみが表示されるよ
+    \end{itemize}
+    \begin{lstlisting}[title=grepコマンドの実行例, label=grep_example]
+    <#green#pi@raspberrypi#>:<#blue#~ $#> grep Do ~/lsfile
+    <#red#Do#>cuments
+    <#red#Do#>wnloads
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{パイプラインとフィルタコマンドを組み合わせよう}
+    標準出力を出すコマンド | フィルタコマンド
+    \begin{itemize}
+        \item 標準出力を出すコマンドの結果をフィルタコマンドに渡すよ
+    \end{itemize}
+    \begin{lstlisting}[title=パイプラインを用いたsortコマンドの実行例, label=sort_example]
+    <#green#pi@raspberrypi#>:<#blue#~ $#> ls ~/03 | sort
+    01
+    02
+    03
+    Bookshelf
+    Desktop
+    Documents
+    Downloads
+    lsfile
+    Music
+    Pictures
+    Public
+    Templates
+    Videos
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}
+    \frametitle{問題をといてみよう！}
+    \begin{itemize}
+        \item 教科書45ページ 問題3-13(6問)
+        \item 教科書46ページ 問題3-14(3問)
+    \end{itemize}
+\end{frame}
+
+\begin{frame}
+    \frametitle{xargsコマンドってなんだろう？}
+    \begin{itemize}
+        \item 標準入力を受け取り、実行したいコマンドの引数として使えるよ
+        \item xargsコマンドを使うと引数にいろいろなものを指定できるよ
+    \end{itemize}
+    \begin{figure}
+        \centering
+        \includesvg[width=0.55\linewidth]{images/chap03/xargs_command.svg}
+    \end{figure}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{xargsコマンドを使う準備をしよう}
+    xargsコマンドを使うためのディレクトリ\textasciitilde/03/rensyu/xargstestを作ろう
+    \begin{lstlisting}
+    <#green#pi@raspberrypi#>:<#blue#~ $#> cd 03/rensyu
+    <#green#pi@raspberrypi#>:<#blue#~/03/rensyu $#> mkdir xargstest
+    <#green#pi@raspberrypi#>:<#blue#~/03/rensyu $#> cp ~/lsfile ./xargstest
+    <#green#pi@raspberrypi#>:<#blue#~/03/rensyu $#> cp ./kokugo/syousetu.txt ./xargstest
+    <#green#pi@raspberrypi#>:<#blue#~/03/rensyu $#> cd xargstest
+    <#green#pi@raspberrypi#>:<#blue#~/03/rensyu/xargstest $#> ls
+    <#magenta#lsfile  syousetu.txt#>
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{xargsコマンドを実際に使ってみよう}
+    \begin{lstlisting}[title=xargsコマンドを使ってcatコマンドを使う]
+    <#green#pi@raspberrypi#>:<#blue#~/03/rensyu/xargstest $#> ls | xargs cat
+    01
+    02
+    03
+    Bookshelf
+    Desktop
+                                                   ...
+    このファイルは、インターネットの図書館、青空文庫（http://www.aozora.gr
+    .jp/）で作られました。入力、校正、制作にあたったのは、ボランティアの皆さんです。
+        
+        
+        
+    https:／／www.aozora.gr.jp/cards/000121/files/628_14895.html<#green#pi@raspberr
+    ypi#>:<#blue#~/03/rensyu/xargs $#>
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}
+    \frametitle{xargsコマンドのオプション}
+    xargs␣-p␣\underline{コマンド}
+    \begin{itemize}
+        \item どのようなコマンドが実行されるかを表示するよ
+    \end{itemize}
+    xargs␣-i␣\underline{コマンド}␣\{\}
+    \begin{itemize}
+        \item 標準入力を1つずつ受け取って{}の中に当てはめ、\underline{コマンド}を実行するよ
+    \end{itemize}
+    xargs␣-L␣数字␣\underline{コマンド}
+    \begin{itemize}
+        \item xargsで一度に\underline{コマンド}を渡す引数の最大数を指定するよ
+        \item 標準出力から渡されたデータ数が-Lオプションの指定した数より大きい場合は、すべての入力が終わるまで\underline{コマンド}が繰り返されるよ
+        \item -iオプションと-Lオプションは一緒に使えないよ
+    \end{itemize}
+\end{frame}
+
+\begin{frame}
+    \frametitle{問題をといてみよう！}
+    \begin{itemize}
+        \item 教科書49ページ 問題3-15(2問)
+    \end{itemize}
+\end{frame}
+
+\begin{frame}
+    \frametitle{置き換えをするコマンド}
+    \begin{tabular}{ll}
+        コマンド & 動作                                                       \\ \hline
+        tr       & 入力された文字を指定する方法で置き換えて出力する           \\
+        sed      & 入力から指定するパターンを見つけ、それを置き換えて出力する \\ \hline
+    \end{tabular}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{trコマンドで文字を置き換えよう}
+    tr␣\underline{置き換えたい文字}␣\underline{置き換える文字}
+    \begin{itemize}
+        \item 文字列中の\underline{置き換えたい文字}を\underline{置き換える文字}に置き換えるよ
+        \item 1文字ごとの置き換えだよ
+        \item 「-」は置き換えられないよ
+        \item 0-9 や A-Z, a-z のように範囲を指定できるよ
+    \end{itemize}
+    \begin{lstlisting}[title=範囲指定を使った置き換え, label=tr_range]
+    <#green#pi@raspberrypi#>:<#blue#~ $#> echo "HELLO, WORLD!" | tr A-Z a-z
+    hello, world!
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{sedコマンドで文字を置き換えよう}
+    sed␣'s/\underline{置き換え対象の文字列}/\underline{置き換え後の文字列}/g'
+    \begin{itemize}
+        \item 文字列中の\underline{置き換え対象の文字列}を\underline{置き換え後の文字列}に置き換えるよ
+        \item 1文字ごとでなく、文字列で置き換えられるよ
+    \end{itemize}
+    \begin{lstlisting}[title=sed sedでの文字の置き換え, label=sed_app]
+    <#green#pi@raspberrypi#>:<#blue#~ $#> echo "Hello, World!" | sed 's/Hello/Hi/g'
+    Hi, World!
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}
+    \frametitle{問題をといてみよう！}
+    \begin{itemize}
+        \item 教科書52ページ 問題3-16(4問)
+    \end{itemize}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{Bashで計算しよう}
+    復習
+    \begin{itemize}
+        \item echo␣\underline{文字} : \underline{文字}をそのまま表示する
+    \end{itemize}
+    \underline{\&()}
+    \begin{itemize}
+        \item コマンドの置き換えを行うよ
+        \item echoコマンドと組み合わせると計算結果を表示できるよ
+    \end{itemize}
+    \begin{lstlisting}[title=echo コマンドでの計算, label=cmdsbs:calc]
+    <#green#pi@raspberrypi#>:<#blue#~ $#> echo $((138 + 395))
+    533
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}
+    \frametitle{問題をといてみよう！}
+    \begin{itemize}
+        \item 教科書53ページ 問題3-17(2問)
+    \end{itemize}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{コマンドに別名を付けよう}
+    alias␣名前='\underline{コマンド}'
+    \begin{itemize}
+        \item \underline{コマンド}の別名として名前を付けられるよ
+    \end{itemize}
+    \begin{itemize}
+        \item ターミナルで\underline{コマンド}を実行するとターミナルが閉じるまで名前の設定は保存されるよ
+        \item 別名を保存するには.bash\_aliasesというファイルを作ってコマンドを書いて、sourceコマンドを実行する必要があるよ
+    \end{itemize}
+    \begin{lstlisting}[title=\textasciitilde/.bash\_aliasesの書き方, label=bashAliasesGrammar1]
+    alias 名前='コマンド'
+    alias name='command'
+                :
+                :
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}
+    \frametitle{問題をといてみよう！}
+    \begin{itemize}
+        \item 教科書55ページ 問題3-18(2問)
+    \end{itemize}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{findコマンドでファイルを探そう}
+    find␣\underline{ディレクトリ}$\ldots$␣-name␣'\underline{パターン}'
+    \begin{itemize}
+        \item \underline{パターン}と同じ名前のファイルがある場所をパスで表示するよ
+        \item \underline{ディレクトリ}$\ldots$の指定がない時はカレントディレクトリを指定しているよ
+    \end{itemize}
+    \begin{lstlisting}[title=rika.pngをfindコマンドで探す]
+    <#green#pi@raspberrypi#>:<#blue#~ $#> find -name rika.png
+    ./rika/rika.png
+    ./03/rensyu/rika.png
+    <#green#pi@raspberrypi#>:<#blue#~ $#>
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}
+    \frametitle{複数ファイルの指定}
+    \begin{itemize}
+        \item コマンドによっては、複数のファイルやディレクトリを指定できるよ
+        \item \underline{ファイル}$\ldots$のように$\ldots$(三点リーダ)があるものは複数指定できるよ
+        \item ls␣-F␣01␣02␣03
+        \begin{itemize}
+            \item 01, 02, 03のディレクトリの中に入ったファイルを見れるよ
+        \end{itemize}
+    \end{itemize}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{ワイルドカード}
+    \begin{itemize}
+        \item ワイルドカードとはどんな文字が入ってもよいという意味だよ
+        \item 複数のファイルなどを指定するときに便利だよ
+    \end{itemize}
+    \begin{lstlisting}[title=ワイルドカードの使い方の例]
+    <#green#pi@raspberrypi#>:<#blue#~ $#> ls -F P*
+    Pictures:
+            
+    Public:
+    <#green#pi@raspberrypi#>:<#blue#~ $#>
+    \end{lstlisting}
+\end{frame}
+
+\begin{frame}
+    \frametitle{問題を解いてみよう！}
+    \begin{itemize}
+        \item 教科書58ページ 問題3-19(3問)
+    \end{itemize}
+\end{frame}
+
+\begin{frame}[fragile]
+    \frametitle{ターミナルで困ったとき}
+    エラーメッセージが出た場合
+    \begin{lstlisting}
+        <#green#pi@raspberrypi#>:<#blue#~ $#> pwb
+        bash: pwb: コマンドが見つかりません
+        <#green#pi@raspberrypi#>:<#blue#~ $#> 
+        \end{lstlisting}
+    \begin{itemize}
+        \item コマンドのスペル(アルファベット)を確かめよう
+    \end{itemize}
+    \begin{lstlisting}
+        <#green#pi@raspberrypi#>:<#blue#~ $#> cd AAA
+        bash: cd: AAA: そのようなファイルやディレクトリはありません
+        <#green#pi@raspberrypi#>:<#blue#~ $#> 
+        \end{lstlisting}
+    \begin{itemize}
+        \item ファイルやディレクトリのスペルを確かめよう
+    \end{itemize}
+\end{frame}
+
+\begin{frame}
+    \frametitle{ターミナルで困ったとき}
+    キーボードで文字が入力できない
+    \begin{itemize}
+        \item Ctrl+Sを入力すると画面がロックされて文字が入力できないように見えるよ
+        \item Ctrl+Qで画面ロックを解除しよう
+    \end{itemize}
+    コマンドが終了しない
+    \begin{itemize}
+        \item 実行中のコマンドはCtrl+Cで終了できるよ
+    \end{itemize}
+    表示される文字がおかしい
+    \begin{itemize}
+        \item Ctrl+Lを入力、またはclearコマンドを実行して画面の内容を消そう
+        \item 直らなかったらresetコマンドを実行しよう
+        \item resetコマンドでも直らないときはターミナルを閉じて、再度開こう
+    \end{itemize}
+\end{frame}
+
+\begin{frame}
+    \frametitle{コマンドをもっと知りたい}
+    \begin{itemize}
+        \item Web検索
+        \begin{itemize}
+            \item bash コマンド名で検索すると、たいていのコマンドの日本語での説明が見つかるよ
+        \end{itemize}
+        \item manで調べる
+        \begin{itemize}
+            \item ターミナルにman コマンド名と入力すると、英語で詳しい使い方が表示されるよ
+        \end{itemize}
+    \end{itemize}
+\end{frame}
+
+\begin{frame}
+    \frametitle{問題をといてみよう！}
+    \begin{itemize}
+        \item 教科書62ページ 問題3-20(8問)
+        \item 教科書63ページ 問題3-21(8問)
+        \item 教科書64ページ 問題3-22(5問)
+    \end{itemize}
+\end{frame}
+
+\begin{frame}
+    \frametitle{チャレンジ問題を解いてみよう}
+    \begin{itemize}
+        \item 教科書39ページ 闇夜を照らすLED
+        \item 教科書40ページ GIFアニメーションの作成
+    \end{itemize}
+\end{frame}

--- a/03/slide_contents/advanced_command.tex
+++ b/03/slide_contents/advanced_command.tex
@@ -107,15 +107,13 @@
 
 \begin{frame}[fragile]
     \frametitle{catコマンド}
+    cat␣\underline{ファイル}$\ldots$
     \begin{itemize}
-        \item cat␣\underline{ファイル}$\ldots$
-        \begin{itemize}
-            \item \underline{ファイル}$\ldots$の中身を標準出力(ディスプレイ)に表示する
-        \end{itemize}
-        \item cat
-        \begin{itemize}
-            \item ファイルを指定しないと標準入力(キーボード)からデータを受け取るよ
-        \end{itemize}
+        \item \underline{ファイル}$\ldots$の中身を標準出力(ディスプレイ)に表示する
+    \end{itemize}
+    cat
+    \begin{itemize}
+        \item ファイルを指定しないと標準入力(キーボード)からデータを受け取るよ
     \end{itemize}
     \begin{lstlisting}[title=catの標準入力・標準出力, label=stdioCat]
     <#green#pi@raspberrypi#>:<#blue#~ $#> cat 
@@ -357,6 +355,10 @@
     \frametitle{問題をといてみよう！}
     \begin{itemize}
         \item 教科書45ページ 問題3-13(6問)
+        \begin{itemize}
+            \item 問題修正 6. \textasciitilde/03/rensyu/kokugo/syousetu.txt の中身から”\textcolor{red}{ごん}” という文字列に一致
+            する行を表示してみましょう
+        \end{itemize}
         \item 教科書46ページ 問題3-14(3問)
     \end{itemize}
 \end{frame}
@@ -434,6 +436,7 @@
 
 \begin{frame}
     \frametitle{置き換えをするコマンド}
+    \footnotesize
     \begin{tabular}{ll}
         コマンド & 動作                                                       \\ \hline
         tr       & 入力された文字を指定する方法で置き換えて出力する           \\

--- a/03/slide_contents/sensorboard.tex
+++ b/03/slide_contents/sensorboard.tex
@@ -44,53 +44,53 @@
   \end{itemize}
 \end{frame}
 
-\begin{frame}
-  \frametitle{LEDを光らせてみよう(1)}
-  \begin{itemize}
-    \item led.hspを実行しよう
-          \begin{itemize}
-            \item 03ディレクトリに移動しよう
-            \item ターミナルで hsed コマンドを使おう
-            \item ファイル\rightarrow 開く\rightarrow led.hsp
-          \end{itemize}
-  \end{itemize}
-\end{frame}
+% \begin{frame}
+%   \frametitle{LEDを光らせてみよう(1)}
+%   \begin{itemize}
+%     \item led.hspを実行しよう
+%           \begin{itemize}
+%             \item 03ディレクトリに移動しよう
+%             \item ターミナルで hsed コマンドを使おう
+%             \item ファイル\rightarrow 開く\rightarrow led.hsp
+%           \end{itemize}
+%   \end{itemize}
+% \end{frame}
 
-\begin{frame}[fragile]
-  \frametitle{LEDを光らせてみよう(2)}
-  \begin{lstlisting}[title=led.hsp,label=led.hsp]
-  #include "hsp3dish.as"   <#blue#; スクリプトの設定を読み込む#>
-  #include "rpz-gpio.as"   <#blue#; スクリプトの設定を読み込む#>
-          redraw 0         <#blue#; 画面更新 (仮想画面に描画)#>
-          font "",30       <#blue#;文字のフォント、サイズを決める#>
-          pos 20, 20       <#blue#;文字の場所を決める#>
-          mes "LEDが光るよ" <#blue#;文字を決める#>
-          redraw 1         <#blue#;画面更新(実際の画面に描画)#>
-  *led
-          gpio 17, 1     <#blue#;GPIO17を点灯させる#>
-          wait 100       <#blue#;0.1 秒待つ#>
-          goto *led      <#blue#;*led まで戻る#>
-          gpio 17, 0     <#blue#;GPIO17を消灯させる#>
-  \end{lstlisting}
-\end{frame}
+% \begin{frame}[fragile]
+%   \frametitle{LEDを光らせてみよう(2)}
+%   \begin{lstlisting}[title=led.hsp,label=led.hsp]
+%   #include "hsp3dish.as"   <#blue#; スクリプトの設定を読み込む#>
+%   #include "rpz-gpio.as"   <#blue#; スクリプトの設定を読み込む#>
+%           redraw 0         <#blue#; 画面更新 (仮想画面に描画)#>
+%           font "",30       <#blue#;文字のフォント、サイズを決める#>
+%           pos 20, 20       <#blue#;文字の場所を決める#>
+%           mes "LEDが光るよ" <#blue#;文字を決める#>
+%           redraw 1         <#blue#;画面更新(実際の画面に描画)#>
+%   *led
+%           gpio 17, 1     <#blue#;GPIO17を点灯させる#>
+%           wait 100       <#blue#;0.1 秒待つ#>
+%           goto *led      <#blue#;*led まで戻る#>
+%           gpio 17, 0     <#blue#;GPIO17を消灯させる#>
+%   \end{lstlisting}
+% \end{frame}
 
-\begin{frame}
-  \frametitle{LEDを光らせてみよう(3)}
-  \begin{itemize}
-    \item gpio 17, 1 の部分でLEDを光らせているよ
-          \begin{itemize}
-            \item 17 は光らせたいLEDのGPIO番号
-            \item 1で点灯、0で消灯
-          \end{itemize}
-  \end{itemize}
-\end{frame}
+% \begin{frame}
+%   \frametitle{LEDを光らせてみよう(3)}
+%   \begin{itemize}
+%     \item gpio 17, 1 の部分でLEDを光らせているよ
+%           \begin{itemize}
+%             \item 17 は光らせたいLEDのGPIO番号
+%             \item 1で点灯、0で消灯
+%           \end{itemize}
+%   \end{itemize}
+% \end{frame}
 
-\begin{frame}
-  \frametitle{問題をといてみよう!}
-  \begin{itemize}
-    \item 教科書28ページ 問題3-7(4問)
-  \end{itemize}
-\end{frame}
+% \begin{frame}
+%   \frametitle{問題をといてみよう!}
+%   \begin{itemize}
+%     \item 教科書28ページ 問題3-7(4問)
+%   \end{itemize}
+% \end{frame}
 
 \begin{frame}
   \frametitle{温度、湿度、気圧、明るさを調べてみよう(1)}
@@ -144,7 +144,38 @@
 \begin{frame}
   \frametitle{問題をといてみよう!}
   \begin{itemize}
-    \item 教科書32ページ 問題3-9(8問)
+    \item 教科書23ページ 問題3-6(8問)
+  \end{itemize}
+\end{frame}
+
+\begin{frame}
+  \frametitle{LEDをチカチカさせよう(1)}
+  \begin{itemize}
+    \item ファイル \rightarrow \sim/03/Ltika.hspを実行しよう
+  \end{itemize}
+\end{frame}
+
+\begin{frame}[fragile]
+  \frametitle{LEDをチカチカさせよう(2)}
+  \begin{lstlisting}[title=\textasciitilde/03/Ltika.hsp,label=Ltika.hsp]
+    #include "hsp3dish.as"		<#blue#;スクリプトの設定を読み込む#>
+    #include "rpz-gpio.as"		<#blue#;スクリプトの設定を読み込む#>
+      redraw 0		<#blue#;画面更新（仮想画面に描画）#>
+      mes "0.5 秒毎に青色の LED がチカチカするよ"
+      redraw 1		<#blue#;画面更新（実際の画面に描画）#>
+    *led
+      gpio 22,0		<#blue#;gpio22 を消灯#>
+      wait 50 		<#blue#;500 ミリ秒待つ#>
+      gpio 22, 1 		<#blue#;gpio22 を点灯#>
+      wait 50 		<#blue#;500 ミリ秒待つ#>
+      goto *led 		<#blue#;*led にジャンプ（繰り返し）#>
+  \end{lstlisting}
+\end{frame}
+
+\begin{frame}
+  \frametitle{問題をといてみよう!}
+  \begin{itemize}
+    \item 教科書25ページ 問題3-7(6問)
   \end{itemize}
 \end{frame}
 
@@ -198,7 +229,7 @@
 \begin{frame}
   \frametitle{問題をといてみよう!}
   \begin{itemize}
-    \item 教科書34ページ 問題3-10(3問)
+    \item 教科書27ページ 問題3-8(4問)
   \end{itemize}
 \end{frame}
 
@@ -269,7 +300,7 @@
 \begin{frame}
   \frametitle{問題をといてみよう!}
   \begin{itemize}
-    \item 教科書36ページ 問題3-11(4問)
+    \item 教科書30ページ 問題3-9(3問)
   \end{itemize}
 \end{frame}
 
@@ -377,21 +408,6 @@
 \begin{frame}
   \frametitle{問題をといてみよう!}
   \begin{itemize}
-    \item 教科書38ページ 問題3-12(3問)
-  \end{itemize}
-\end{frame}
-
-\begin{frame}
-  \frametitle{チャレンジ問題を解いてみよう}
-  \begin{itemize}
-    \item 教科書39ページ 闇夜を照らすLED
-    \item 教科書40ページ GIFアニメーションの作成
-  \end{itemize}
-\end{frame}
-
-\begin{frame}
-  \frametitle{参考文献}
-  \begin{itemize}
-  \item Indoor Corgi Elec. RPZ-IR-Sensor https://www.indoorcorgielec.com/products/rpz-ir-sensor/
+    \item 教科書32ページ 問題3-10(3問)
   \end{itemize}
 \end{frame}

--- a/03/slide_contents/shell_command.tex
+++ b/03/slide_contents/shell_command.tex
@@ -56,6 +56,18 @@
     \end{itemize}
 \end{frame}
 
+\begin{frame}[fragile]
+    \frametitle{今回使うファイルをコマンドでコピーしよう}
+    \begin{itemize}
+        \item 下のコマンドを実行しよう
+        \item 「\textasciitilde(チルダ)」記号とスペースに気をつけよう
+    \end{itemize}
+    \begin{lstlisting}[caption=使うファイルのコピー,label=workfilecopy]
+    <#green#pi@raspberrypi#>:<#blue#~ $#> cp -r /usr/local/share/ome/03 ~
+    <#green#pi@raspberrypi#>:<#blue#~ $#>
+    \end{lstlisting}
+\end{frame}
+
 \begin{frame}
     \frametitle{コマンドを使ってみよう}
     \begin{itemize}
@@ -63,15 +75,17 @@
         \begin{itemize}
             \item カレントディレクトリ(自分がどのディレクトリにいるか)がわかるよ
         \end{itemize}
-        \item ls -F ディレクトリ
+        \item ls -F \underline{ファイル}$\ldots$
         \begin{itemize}
-            \item ディレクトリの中のファイルを見ることができるよ
+            \item \underline{ファイル}$\ldots$を表示するよ
+            \item \underline{ファイル}$\ldots$を\underline{ディレクトリ}$\ldots$にするとディレクトリの中にあるファイルやディレクトリを表示するよ
+            \item \underline{ファイル}$\ldots$を指定しないときはカレントディレクトリの中を表示するよ
         \end{itemize}
     \end{itemize}
 \end{frame}
 
 \begin{frame}
-    \frametitle{Tabキーで楽しよう}
+    \frametitle{便利なTab(タブ)キーを使ってみよう}
     \begin{itemize}
         \item Tab（タブ）キーを押すとそれまでに入力した文字から残りの文字をコンピュータが推測してくれるよ
         \item いくつかあるときは候補を表示するよ
@@ -83,12 +97,27 @@
 \end{frame}
 
 \begin{frame}
-    \frametitle{問題をといてみよう！}
+    \frametitle{コマンド履歴}
     \begin{itemize}
-        \item 教科書4ページ 問題3-1
+        \item bashは今まで受け付けたコマンドを記録しているよ
+        \item 前に使ったコマンドを表示できるよ
     \end{itemize}
+    \begin{figure}[h]
+        \center
+        \begin{tabular}{ll}\hline
+          キー & 機能 \\ \hline
+          ↑ または Ctrl+P & ひとつ前のコマンドを表示\\
+          ↓ または Ctrl+N & ひとつ後ろのコマンドを表示\\ \hline
+        \end{tabular}
+    \end{figure}
 \end{frame}
 
+\begin{frame}
+    \frametitle{問題をといてみよう！}
+    \begin{itemize}
+        \item 教科書4ページ 問題3-1(5問)
+    \end{itemize}
+\end{frame}
 
 \begin{frame}
     \frametitle{ファイルって何だろう}
@@ -173,10 +202,21 @@
 \end{frame}
 
 \begin{frame}
-    \frametitle{問題をといてみよう！}
+    \frametitle{ディレクトリの上下関係}
     \begin{itemize}
-        \item 教科書6ページ 問題3-2
+        \item 下のディレクトリ / サブディレクトリ
+        \begin{itemize}
+            \item 注目しているディレクトリの中に入っているディレクトリ
+        \end{itemize}
+        \item 上のディレクトリ / 親ディレクトリ
+        \begin{itemize}
+            \item 注目しているディレクトリを中に持っているディレクトリ
+        \end{itemize}
     \end{itemize}
+    \begin{figure}[h]
+        \centering
+        \includesvg[width=0.7\columnwidth]{images/chap03/directory_relation.svg}
+    \end{figure}
 \end{frame}
 
 \begin{frame}
@@ -301,83 +341,91 @@
 \begin{frame}
     \frametitle{問題をといてみよう！}
     \begin{itemize}
-        \item 教科書9\textasciitilde10ページ 問題3-3
+        \item 教科書9\textasciitilde10ページ 問題3-2(5問)
     \end{itemize}
 \end{frame}
 
 \begin{frame}
     \frametitle{ターミナルでファイルを操作してみよう}
+    cd␣\underline{ディレクトリ}
     \begin{itemize}
-        \item cd␣ディレクトリ
-        \begin{itemize}
-            \item カレントディレクトリを指定したディレクトリに移動するよ
-        \end{itemize}
-        \item cd
-        \begin{itemize}
-            \item ホームディレクトリに移動するよ
-        \end{itemize}
-        \item cat␣ファイル
-        \begin{itemize}
-            \item ファイルに書かれている文字を表示するよ
-        \end{itemize}
-        \item cp␣ファイル1␣ファイル2
-        \begin{itemize}
-            \item ファイル1をファイル2という名前でコピーするよ
-        \end{itemize}
-        \item cp␣-r␣ディレクトリ1␣ディレクトリ2
-        \begin{itemize}
-            \item ディレクトリ1をディレクトリ2という名前でコピーするよ
-        \end{itemize}
-        \item mv␣移動したいファイルやディレクトリ␣移動先
-        \begin{itemize}
-            \item ファイルやディレクトリを移動するよ
-        \end{itemize}
-        \item mv␣ファイルやディレクトリの名前␣変えたい名前
-        \begin{itemize}
-            \item ファイルやディレクトリの名前を変えるよ
-        \end{itemize}
+        \small
+        \item カレントディレクトリを\underline{ディレクトリ}に移動するよ
+    \end{itemize}
+    cd
+    \begin{itemize}
+        \small
+        \item ホームディレクトリに移動するよ
+    \end{itemize}
+    cat␣\underline{ファイル}$\ldots$
+    \begin{itemize}
+        \small
+        \item \underline{ファイル}$\ldots$に書かれている文字を表示するよ
+    \end{itemize}
+    cp␣\underline{ファイル1}␣\underline{ファイル2}
+    \begin{itemize}
+        \small
+        \item \underline{ファイル1}を\underline{ファイル2}という名前でコピーするよ
+    \end{itemize}
+    cp␣\underline{ファイル}$\ldots$␣\underline{ディレクトリ}
+    \begin{itemize}
+        \small
+        \item \underline{ファイル}$\ldots$で指定されたファイルを同じ名前で\underline{ディレクトリ}の下にコピーするよ
+    \end{itemize}
+    cp␣-r␣\underline{ディレクトリ1}␣\underline{ディレクトリ2}
+    \begin{itemize}
+        \small
+        \item \underline{ディレクトリ1}を\underline{ディレクトリ2}という名前でコピーするよ
+    \end{itemize}
+\end{frame}
+
+\begin{frame}
+    \frametitle{ターミナルでファイルを操作してみよう}
+    mv␣\underline{ファイルやディレクトリ}$\ldots$␣\underline{移動先ディレクトリ}
+    \begin{itemize}
+        \item \underline{ファイルやディレクトリ}$\ldots$を\underline{移動先ディレクトリ}に移動するよ
+    \end{itemize}
+    mv␣\underline{名前}␣\underline{変えたい名前}
+    \begin{itemize}
+        \item ファイルやディレクトリの\underline{名前}を\underline{変えたい名前}に変えるよ
     \end{itemize}
 \end{frame}
 
 \begin{frame}
     \frametitle{問題をといてみよう！}
     \begin{itemize}
-        \item 教科書13ページ 問題3-4
-        \item 教科書14ページ 問題3-5
+        \item 教科書14ページ 問題3-3(5問)
+        \item 教科書15ページ 問題3-4(5問)
     \end{itemize}
 \end{frame}
 
 \begin{frame}
     \frametitle{ターミナルでファイルを操作してみよう}
+    less␣\underline{ファイル}$\ldots$
     \begin{itemize}
-        \item less␣ファイル
-        \begin{itemize}
-            \item ファイルに書かれている文字を一画面ずつ見ることができるよ
-            \item eを押すと一行進んで、yを押すと一行戻るよ
-            \item qを押すと終わるよ
-        \end{itemize}
-        \item mousepad␣ファイル␣\&
-        \begin{itemize}
-            \item mousepadを使ってファイルを作成または編集するよ
-        \end{itemize}
+        \item \underline{ファイル}$\ldots$に書かれている文字を一画面ずつ見ることができるよ
+        \item eを押すと一行進んで、yを押すと一行戻るよ
+        \item qを押すと終わるよ
+    \end{itemize}
+    mousepad␣ファイル␣\&
+    \begin{itemize}
+        \item mousepadを使ってファイルを作成または編集するよ
     \end{itemize}
 \end{frame}
 
 \begin{frame}
     \frametitle{ターミナルでファイルを操作してみよう}
+    mkdir␣\underline{ディレクトリ}$\ldots$
     \begin{itemize}
-        \item mkdir␣ディレクトリ
-        \begin{itemize}
-            \item 新しいディレクトリを作ることができるよ
-        \end{itemize}
-        \item rm␣ファイル
-        \begin{itemize}
-            \item ファイルを消したいときは
-        \end{itemize}
-        \item rm␣-r␣ディレクトリ
-        \begin{itemize}
-            \item ディレクトリを消したいときは
-        \end{itemize}
+        \item 新しいディレクトリを作ることができるよ
+    \end{itemize}
+    rm␣\underline{ファイル}$\ldots$
+    \begin{itemize}
+        \item \underline{ファイル}$\ldots$を消すよ
+    \end{itemize}
+    rm␣-r␣\underline{ディレクトリ}$\ldots$
+    \begin{itemize}
+        \item \underline{ディレクトリ}$\ldots$を消すよ
     \end{itemize}
     \begin{figure}[h]
         \centering
@@ -388,475 +436,6 @@
 \begin{frame}
     \frametitle{問題をといてみよう！}
     \begin{itemize}
-        \item 教科書17ページ 問題3-6
+        \item 教科書18ページ 問題3-5(6問)
     \end{itemize}
-\end{frame}
-
-\begin{frame}
-    \frametitle{コマンドの入出力}
-    コマンドを実行すると３つのデータの通り道(チャネル)が準備されるよ
-    \begin{itemize}
-        \item 標準入力
-        \item 標準出力
-        \item 標準エラー出力
-    \end{itemize}
-    \begin{figure}[h]
-        \centering
-        \includesvg[width=0.8\columnwidth]{images/chap03/std_in_out_err.svg}
-    \end{figure}
-\end{frame}
-
-\begin{frame}[fragile]
-    \frametitle{catコマンド}
-    \begin{itemize}
-        \item cat␣ファイル
-        \begin{itemize}
-            \item ファイルの中身を標準出力(ディスプレイ)に表示する
-        \end{itemize}
-        \item cat
-        \begin{itemize}
-            \item ファイルを指定しないと標準入力(キーボード)からデータを受け取るよ
-        \end{itemize}
-    \end{itemize}
-    \begin{lstlisting}[title=catの標準入力・標準出力, label=stdioCat]
-    <#green#pi@raspberrypi#>:<#blue#~ $#> cat 
-    sansu <Enter> <- 標準入力（キーボード）からの入力
-    sansu         <- 標準出力（ディスプレイ）への出力
-    <Ctrl+D>      <- 標準入力からEOFを入力し、入力が終了したことを伝える
-    <#green#pi@raspberrypi#>:<#blue#~ $#>
-    \end{lstlisting}
-\end{frame}
-
-\begin{frame}
-    \frametitle{リダイレクトってなんだろう？}
-    \begin{itemize}
-        \item 標準入力、標準出力、標準エラー出力の出力先をファイルに変更することだよ
-    \end{itemize}
-    \begin{figure}
-        \centering
-        \includesvg[width=0.7\linewidth]{images/chap03/redirect.svg}
-    \end{figure}
-\end{frame}
-
-\begin{frame}[fragile]
-    \frametitle{リダイレクトの例}
-    \begin{lstlisting}[title=lsの出力をリダイレクトする, label=redirectLs]
-    <#green#pi@raspberrypi#>:<#blue#~ $#> ls 
-    <#blue#01  03         Desktop    Downloads  Pictures  Templates
-    02  Bookshelf  Documents  Music      Public    Videos#>
-    <#green#pi@raspberrypi#>:<#blue#~ $#> ls > lsfile
-    <#green#pi@raspberrypi#>:<#blue#~ $#> cat lsfile
-    01
-    02
-    03
-    Bookshelf
-    Desktop
-    Documents
-    Downloads
-    Music
-    Pictures
-    Public
-    Templates
-    Videos
-    lsfile
-    \end{lstlisting}
-\end{frame}
-
-\begin{frame}
-    \frametitle{パイプライン}
-    \begin{itemize}
-        \item パイプ（｜）を使って標準出力と標準入力をつなげることができるよ
-    \end{itemize}
-    \begin{figure}
-        \centering
-        \includesvg[width=1\linewidth]{images/chap03/pipe.svg}
-    \end{figure}
-\end{frame}
-
-\begin{frame}[fragile]
-    \frametitle{パイプラインの例}
-    \begin{lstlisting}[title=lsコマンドの出力をパイプでlessコマンドに渡す, label=redirectCat]
-    <#green#pi@raspberrypi#>:<#blue#~ $#> ls | less
-    01
-    02
-    03
-    Bookshelf
-    Desktop
-    Documents
-    Downloads
-    Music
-    Pictures
-    Public
-    Templates
-    Videos
-    lsfile
-    \end{lstlisting}
-\end{frame}
-
-\begin{frame}
-    \frametitle{xargsコマンドってなんだろう？}
-    \begin{itemize}
-        \item 標準入力を受け取り、実行したいコマンドの引数として使えるよ
-        \item xargsコマンドを使うと引数にいろいろなものを指定できるよ
-    \end{itemize}
-    \begin{figure}
-        \centering
-        \includesvg[width=0.55\linewidth]{images/chap03/xargs_command.svg}
-    \end{figure}
-\end{frame}
-
-\begin{frame}[fragile]
-    \frametitle{xargsコマンドを使う準備をしよう}
-    \begin{itemize}
-        \item xargsコマンドを使うためのディレクトリ\textasciitilde/03/rensyu/xargstestを作ろう
-    \end{itemize}
-    \begin{lstlisting}
-    <#green#pi@raspberrypi#>:<#blue#~ $#> cd 03/rensyu
-    <#green#pi@raspberrypi#>:<#blue#~/03/rensyu $#> mkdir xargstest
-    <#green#pi@raspberrypi#>:<#blue#~/03/rensyu $#> cp ~/lsfile ./xargstest
-    <#green#pi@raspberrypi#>:<#blue#~/03/rensyu $#> cp ./kokugo/syousetu.txt ./xargstest
-    <#green#pi@raspberrypi#>:<#blue#~/03/rensyu $#> cd xargstest
-    <#green#pi@raspberrypi#>:<#blue#~/03/rensyu/xargstest $#> ls
-    <#magenta#lsfile  syousetu.txt#>
-    \end{lstlisting}
-\end{frame}
-
-\begin{frame}[fragile]
-    \frametitle{xargsコマンドを実際に使ってみよう}
-    \begin{lstlisting}[title=xargsコマンドを使ってcatコマンドを使う]
-    <#green#pi@raspberrypi#>:<#blue#~/03/rensyu/xargstest $#> ls | xargs cat
-    01
-    02
-    03
-    Bookshelf
-    Desktop
-                                                   ...
-    このファイルは、インターネットの図書館、青空文庫（http://www.aozora.gr.jp/）で作られました。
-    入力、校正、制作にあたったのは、ボランティアの皆さんです。
-        
-        
-        
-    https://www.aozora.gr.jp/cards/000121/files/628_14895.html
-    <#green#pi@raspberrypi#>:<#blue#~/03/rensyu/xargs $#>
-    \end{lstlisting}
-\end{frame}
-
-\begin{frame}[fragile]
-    \frametitle{出力を作るコマンド}
-    \begin{itemize}
-        \item seq␣数字1␣数字2
-        \begin{itemize}
-            \item 数字1から数字2までの数字を順番に出力するよ
-            \begin{lstlisting}
-            <#green#pi@raspberrypi#>:<#blue#~/03/rensyu/xargs $#> seq 1 5
-            1
-            2
-            3
-            4
-            5
-            <#green#pi@raspberrypi#>:<#blue#~/03/rensyu/xargs $#>
-            \end{lstlisting}
-        \end{itemize}
-        \item echo␣文字
-        \begin{itemize}
-            \item 文字をそのまま出力するよ
-            \begin{lstlisting}
-            <#green#pi@raspberrypi#>:<#blue#~/03/rensyu/xargs $#> echo hello
-            hello
-            <#green#pi@raspberrypi#>:<#blue#~/03/rensyu/xargs $#>
-            \end{lstlisting}
-        \end{itemize}
-    \end{itemize}
-\end{frame}
-
-\begin{frame}
-    \frametitle{xargsコマンドのオプション}
-    \begin{itemize}
-        \item xargs␣-p␣コマンド
-        \begin{itemize}
-            \item どのようなコマンドが実行されるかを表示するよ
-        \end{itemize}
-        \item xargs␣-i␣コマンド␣\{\}
-        \begin{itemize}
-            \item 標準入力を1つずつ受け取って{}の中に当てはめ、コマンドを実行するよ
-        \end{itemize}
-        \item xargs␣-L␣数字␣コマンド
-        \begin{itemize}
-            \item xargsで一度にコマンドを渡す引数の最大数を指定するよ
-            \item 標準出力から渡されたデータ数が-Lオプションの指定した数より大きい場合は、すべての入力が終わるまでコマンドが繰り返されるよ
-            \item -iオプションと-Lオプションは一緒に使えないよ
-        \end{itemize}
-    \end{itemize}
-\end{frame}
-
-\begin{frame}
-    \frametitle{出力を作るコマンド}
-    \begin{tabular}{ll}
-        コマンド & 動作                                         \\ \hline
-        ls       & ファイルやディレクトリを出力する             \\
-        du       & ディレクトリの中のファイルの大きさを報告する \\
-        wc       & 入力の文字数・単語数・行数を出力する         \\
-        echo     & 文字をそのまま出力する                       \\ \hline
-    \end{tabular}
-\end{frame}
-
-\begin{frame}
-    \frametitle{duコマンド}
-    du␣大きさを調べたいディレクトリやファイルのパス
-    \begin{itemize}
-        \item ディレクトリやファイルの大きさを報告するコマンドだよ
-    \end{itemize}
-    duコマンドのオプション
-    \begin{itemize}
-        \item  -hオプション
-        \begin{itemize}
-            \item ディレクトリの大きさの数字に単位を付けるよ
-        \end{itemize}
-        \item -aオプション
-        \begin{itemize}
-            \item ディレクトリ内のファイルの大きさも表示するよ
-        \end{itemize}
-        \item -sオプション
-        \begin{itemize}
-            \item ディレクトリの大きさの合計のみを表示するよ
-        \end{itemize}
-    \end{itemize}
-\end{frame}
-
-\begin{frame}[fragile]
-    \frametitle{wcコマンド}
-    wc␣対象のファイルのパス
-    \begin{itemize}
-        \item 入力の文字数・単語数・行数を出力するコマンドだよ
-    \end{itemize}
-    \begin{lstlisting}[title=wcコマンドの実行例, label=wc_example]
-    <#green#pi@raspberrypi#>:<#blue#~ $#> wc ~/lsfile
-    13 13 93 /home/pi/lsfile
-    \end{lstlisting}
-\end{frame}
-
-\begin{frame}
-    \frametitle{フィルタコマンド}
-    \begin{tabular}{ll}
-        コマンド & 動作                               \\ \hline
-        cat      & 入力をなにもせずに出力する         \\
-        tac      & 行を逆順に出力する                 \\
-        shuf     & 行をランダムに入れ替えて出力する   \\
-        head     & 先頭のいくつかの行を表示する       \\
-        tail     & 末尾のいくつかの行を表示する       \\
-        sort     & 行を順番にならべかえる             \\
-        grep     & 検索パターンに一致する行を出力する \\ \hline
-    \end{tabular}
-\end{frame}
-
-\begin{frame}[fragile]
-    \frametitle{tacコマンド}
-    tac␣表示したいファイルのパス
-    \begin{itemize}
-        \item 行を逆順に出力するコマンドだよ
-    \end{itemize}
-    \begin{lstlisting}[title=tacコマンドの実行例, label=tac_example]
-    <#green#pi@raspberrypi#>:<#blue#~ $#> tac ~/lsfile
-    lsfile
-    Videos
-    Templates
-    Public
-    Pictures
-    Music
-    Downloads
-    Documents
-    Desktop
-    Bookshelf
-    03
-    02
-    01 
-    \end{lstlisting}
-\end{frame}
-
-\begin{frame}[fragile]
-    \frametitle{shufコマンド}
-    shuf␣表示したいファイルのパス
-    \begin{itemize}
-        \item 行をランダムに入れ替えて出力するコマンドだよ
-    \end{itemize}
-    \begin{lstlisting}[title=shufコマンドの実行例, label=shuf_example]
-    <#green#pi@raspberrypi#>:<#blue#~ $#> shuf ~/lsfile
-    03
-    Desktop
-    Documents
-    02
-    Music
-    01
-    Videos
-    Pictures
-    Bookshelf
-    Templates
-    Public
-    lsfile
-    Downloads
-    \end{lstlisting}
-\end{frame}
-
-\begin{frame}[fragile]
-    \frametitle{headコマンド}
-    head␣表示したいファイルのパス␣-n␣行数
-    \begin{itemize}
-        \item 先頭のいくつかの行を表示するコマンドだよ
-        \item 先頭から指定した行数分だけ表示されるよ
-    \end{itemize}
-    \begin{lstlisting}[title=headコマンドの実行例, label=shuf_example]
-    <#green#pi@raspberrypi#>:<#blue#~ $#> head ~/lsfile -n 2
-    01
-    02
-    \end{lstlisting}
-\end{frame}
-
-\begin{frame}[fragile]
-    \frametitle{tailコマンド}
-    tail␣表示したいファイルのパス␣-n␣行数
-    \begin{itemize}
-        \item 末尾のいくつかの行を表示するコマンドだよ
-        \item 末尾から指定した行数分だけ表示されるよ
-    \end{itemize}
-    \begin{lstlisting}[title=tailコマンドの実行例, label=shuf_example]
-    <#green#pi@raspberrypi#>:<#blue#~ $#> tail ~/lsfile -n 2
-    Videos
-    lsfile
-    \end{lstlisting}
-\end{frame}
-
-\begin{frame}[fragile]
-    \frametitle{sortコマンド}
-    sort␣表示したいファイルのパス
-    \begin{itemize}
-        \item 行を順番に並べ替えるコマンドだよ
-        \item ファイルの名前が数字のものが先に表示されるよ
-    \end{itemize}
-    \begin{lstlisting}[title=sortコマンドの実行例, label=sort_example]
-    <#green#pi@raspberrypi#>:<#blue#~ $#> sort ~/lsfile
-    01
-    02
-    03
-    Bookshelf
-    Desktop
-    Documents
-    Downloads
-    lsfile
-    Music
-    Pictures
-    Public
-    Templates
-    Videos
-    \end{lstlisting}
-\end{frame}
-
-\begin{frame}[fragile]
-    \frametitle{grepコマンド}
-    grep␣検索パターン␣表示したいファイルのパス
-    \begin{itemize}
-        \item 検索パターンに一致する行を出力するコマンドだよ
-        \item 一致する文字列は赤字で表示されるよ
-        \item 一致する行がある場合はその行のみが表示されるよ
-    \end{itemize}
-    \begin{lstlisting}[title=grepコマンドの実行例, label=grep_example]
-    <#green#pi@raspberrypi#>:<#blue#~ $#> grep 03 ~/lsfile
-    <#red#03#>
-    \end{lstlisting}
-\end{frame}
-
-\begin{frame}[fragile]
-    \frametitle{パイプラインとフィルタコマンドを組み合わせよう}
-    標準出力を出すコマンド | フィルタコマンド
-    \begin{itemize}
-        \item 標準出力を出すコマンドの結果をフィルタコマンドに渡すよ
-    \end{itemize}
-    \begin{lstlisting}[title=パイプラインを用いたsortコマンドの実行例, label=sort_example]
-    <#green#pi@raspberrypi#>:<#blue#~ $#> ls ~/03 | sort
-    01
-    02
-    03
-    Bookshelf
-    Desktop
-    Documents
-    Downloads
-    lsfile
-    Music
-    Pictures
-    Public
-    Templates
-    Videos
-    \end{lstlisting}
-\end{frame}
-
-\begin{frame}
-    \frametitle{置き換えをするコマンド}
-    \begin{tabular}{ll}
-        コマンド & 動作                                                       \\ \hline
-        tr       & 入力された文字を指定する方法で置き換えて出力する           \\
-        sed      & 入力から指定するパターンを見つけ、それを置き換えて出力する \\ \hline
-    \end{tabular}
-\end{frame}
-
-\begin{frame}[fragile]
-    \frametitle{trコマンドで文字を置き換えよう}
-    tr␣置き換えたい文字␣置き換える文字
-    \begin{itemize}
-        \item 文字列中の特定の文字を別の文字に置き換えるよ
-        \item 1文字ごとの置き換えだよ
-        \item 「-」は置き換えられないよ
-        \item 0-9 や A-Z, a-z のように範囲を指定できるよ
-    \end{itemize}
-    \begin{lstlisting}[title=範囲指定を使った置き換え, label=tr_range]
-    <#green#pi@raspberrypi#>:<#blue#~ $#> echo "HELLO, WORLD!" | tr A-Z a-z
-    hello, world!
-    \end{lstlisting}
-\end{frame}
-
-\begin{frame}[fragile]
-    \frametitle{sedコマンドで文字を置き換えよう}
-    sed␣'s/置き換え対象の文字列/置き換え後の文字列/g'
-    \begin{itemize}
-        \item 文字列中の特定の文字列を別の文字列に置き換えるよ
-        \item 1文字ごとでなく、文字列で置き換えられるよ
-    \end{itemize}
-    \begin{lstlisting}[title=sed sedでの文字の置き換え, label=sed_app]
-    <#green#pi@raspberrypi#>:<#blue#~ $#> echo "Hello, World!" | sed 's/Hello/Hi/g'
-    Hi, World!
-    \end{lstlisting}
-\end{frame}
-
-\begin{frame}[fragile]
-    \frametitle{Bashで計算しよう}
-    復習
-    \begin{itemize}
-        \item echo␣文字 : 文字をそのまま表示する
-    \end{itemize}
-    \&()
-    \begin{itemize}
-        \item コマンドの置き換えを行うよ
-        \item echoコマンドと組み合わせると計算結果を表示できるよ
-    \end{itemize}
-    \begin{lstlisting}[title=echo コマンドでの計算, label=cmdsbs:calc]
-    <#green#pi@raspberrypi#>:<#blue#~ $#> echo $((138 + 395))
-    533
-    \end{lstlisting}
-        
-\end{frame}
-
-\begin{frame}[fragile]
-    \frametitle{コマンドに別名を付けよう}
-    alias␣名前='コマンド'
-    \begin{itemize}
-        \item コマンドの別名として名前を付けられるよ
-    \end{itemize}
-    \begin{itemize}
-        \item ターミナルでコマンドを実行するとターミナルが閉じるまで名前の設定は保存されるよ
-        \item 別名を保存するには.bash\_aliasesというファイルを作ってコマンドを書いて、sourceコマンドを実行する必要があるよ
-    \end{itemize}
-    \begin{lstlisting}[title=\textasciitilde/.bash\_aliasesの書き方, label=bashAliasesGrammar1]
-    alias 名前='コマンド'
-    alias name='command'
-                :
-                :
-    \end{lstlisting}
 \end{frame}


### PR DESCRIPTION
#576 

## 追加したスライド
* 3章で使うファイルのコピー方法
* コマンド履歴
* ディレクトリの上下関係
* LEDをチカチカさせよう
* 空のファイルを作る(touchコマンド)
* findコマンドでファイルを探す
* 複数ファイルの指定
* ワイルドカード
* ターミナルで困ったときの対応
* コマンドの検索
## 修正
* コマンド中のファイルやディレクトリなどに下線を追加
* 複数ファイル指定できるものに三点リーダーを追加
* 問題番号・ページ数
* スライドの入れ替え