### PR TITLE
【第６回】gettimeの実行例の更新

### DIFF
--- a/06/contents/chap06_04_3.tex
+++ b/06/contents/chap06_04_3.tex
@@ -34,7 +34,7 @@ mmplay 0	<#blue#;音声ファイルを再生する#>
 stop
 \end{lstlisting}
 
-4行目の代入によって、変数dateにたとえば2023年8月20日と、日付をあらわす文字列が代入されます。これが、11行目と12行目の\code{jtload}命令、\code{mmplay}命令によって読み上げられます。\\
+4行目の代入によって、変数dateにたとえば2024年9月21日と、日付をあらわす文字列が代入されます。これが、11行目と12行目の\code{jtload}命令、\code{mmplay}命令によって読み上げられます。\\
 
 \begin{tcolorbox}[title=\useOmetoi]
 \begin{enumerate}


### PR DESCRIPTION
diff
`2023年8月20日` -> `2024年9月21日`
第6回の講義が9/21(土)に行われると考えこの変更を加えたが，もしそうでなければ再更新