### PR TITLE
【第６回】ディレクトリのコピー先を06から07にする

### DIFF
--- a/06/contents/chap06_01.tex
+++ b/06/contents/chap06_01.tex
@@ -8,7 +8,11 @@
 
 \subsection{教材を自分のフォルダに置こう}
 まずは、今回利用する教材をコピーしましょう。
-前回までと同じように、\nobreak/usr/local/share/ome にあるフォルダ 06 を自分のホームディレクトリにコピーしてください。
+前回までと同じように、\nobreak/usr/local/share/ome にあるフォルダ 06 を自分のホームディレクトリに 07 という名前でコピーしてください。
+\begin{lstlisting}[caption=ターミナルを使ったディレクトリのコピー,label=workfilecopy]
+<#green#pi@raspberrypi#>:<#blue#~ $#> cp -r /usr/local/share/ome/06 ~/07/
+<#green#pi@raspberrypi#>:<#blue#~ $#>
+\end{lstlisting}
 
 \newpage
 \section{音声合成}

--- a/06/contents/chap06_01.tex
+++ b/06/contents/chap06_01.tex
@@ -8,7 +8,7 @@
 
 \subsection{教材を自分のフォルダに置こう}
 まずは、今回利用する教材をコピーしましょう。
-前回までと同じように、\nobreak/usr/local/share/ome にあるフォルダ 06 を自分のホームディレクトリに 07 という名前でコピーしてください。
+\nobreak/usr/local/share/ome にあるフォルダ 06 を自分のホームディレクトリに 07 という名前でコピーしてください。
 \begin{lstlisting}[caption=ターミナルを使ったディレクトリのコピー,label=workfilecopy]
 <#green#pi@raspberrypi#>:<#blue#~ $#> cp -r /usr/local/share/ome/06 ~/07/
 <#green#pi@raspberrypi#>:<#blue#~ $#>

--- a/06/contents/chap06_04_1.tex
+++ b/06/contents/chap06_04_1.tex
@@ -1,6 +1,6 @@
 \newpage
 \section{OpenJTalkに文を読み上げてもらう}
-ここでは音声合成ソフトウェアOpenJTalkの\ruby{紹介}{しょう|かい}をします。まずは文を読み上げるHSPプログラムを紹介します。openjtalk.hsp をHSPスクリプトエディタで開いてください。openjtalk.hsp は  \textasciitilde /06/ の中にあります。\\
+ここでは音声合成ソフトウェアOpenJTalkの\ruby{紹介}{しょう|かい}をします。まずは文を読み上げるHSPプログラムを紹介します。openjtalk.hsp をHSPスクリプトエディタで開いてください。openjtalk.hsp は  \textasciitilde /07/ の中にあります。\\
 
 \begin{lstlisting}[caption=openjtalk.hsp,label=openjtalk.hsp]
 #include "hsp3dish.as"
@@ -34,7 +34,7 @@ jtload <読み上げ文字列>, <バッファ番号>\\
 
 \begin{tcolorbox}[title=\useOmetoi]
 \begin{enumerate}
-        \addex{「本日は青天なり」と読み上げるようにプログラムを書き変えて、sunny.hspという名前で \textasciitilde /06/に\ruby{保存}{ほ|ぞん}し、実行しましょう。\\ヒント：\code{jtload "子どもIT\ruby{未来塾}{み|らい|じゅく}", 0} を書き\ruby{換}{か}えます。}
+        \addex{「本日は青天なり」と読み上げるようにプログラムを書き変えて、sunny.hspという名前で \textasciitilde /07/に\ruby{保存}{ほ|ぞん}し、実行しましょう。\\ヒント：\code{jtload "子どもIT\ruby{未来塾}{み|らい|じゅく}", 0} を書き\ruby{換}{か}えます。}
 \addex{時間があったらやりましょう。\\好きな言葉を読み上げさせましょう。}
 \end{enumerate}
 \end{tcolorbox}

--- a/06/contents/chap06_04_2.tex
+++ b/06/contents/chap06_04_2.tex
@@ -5,7 +5,7 @@
 
 % TODO: relative or absolute path
 <声音ファイル>には、 \ruby{拡張子}{かく|ちょう|し}が .htsvoice であるようなファイルへのパスを指定します。\\
-みなさんのRaspberry Piにはいくつかの声音ファイルがすでにダウンロードされています。  \textasciitilde /06/htsvoice-tohoku-f01を見てみてください。
+みなさんのRaspberry Piにはいくつかの声音ファイルがすでにダウンロードされています。  \textasciitilde /07/htsvoice-tohoku-f01を見てみてください。
 
 \begin{itemize}
 \item htsvoice-tohoku-f01/tohoku-f01-neutral.htsvoice
@@ -14,7 +14,7 @@
 \item htsvoice-tohoku-f01/tohoku-f01-sad.htsvoice
 \end{itemize}
 
-が利用できます。例を示します。 \textasciitilde /06/voice.hsp をHSPスクリプトエディタで開いてみましょう。\\
+が利用できます。例を示します。 \textasciitilde /07/voice.hsp をHSPスクリプトエディタで開いてみましょう。\\
 
 \begin{lstlisting}[caption=voice.hsp,label=voice.hsp]
 #include "hsp3dish.as"
@@ -33,10 +33,10 @@ stop
 
 8行目までは前と同じです。9行目でsetvoiceが使用されています\\
 \code{setvoice "htsvoice-tohoku-f01/tohoku-f01-sad.htsvoice"}\\
-\code{voice.hsp} は \code{\textasciitilde /06} にあるので、
+\code{voice.hsp} は \code{\textasciitilde /07} にあるので、
 \code{voice.hsp} 内に書かれた \code{htsvoice-tohoku-f01/tohoku-f01-sad.htsvoice}
-は \code{\textasciitilde /06} から\ruby{探}{さが}されます。
-この行\ruby{以降}{い|こう}、jtloadが\ruby{呼}{よ}び出されると \code{\textasciitilde /06/htsvoice-tohoku-f01/tohoku-f01-sad.htsvoice}
+は \code{\textasciitilde /07} から\ruby{探}{さが}されます。
+この行\ruby{以降}{い|こう}、jtloadが\ruby{呼}{よ}び出されると \code{\textasciitilde /07/htsvoice-tohoku-f01/tohoku-f01-sad.htsvoice}
 という声音が使用されます。ダブルクォーテーションで囲われている部分を\ruby{変更}{へん|こう}することで、別の声音にすることができます。\\
 
 \begin{tcolorbox}[title=\useOmetoi]

--- a/06/contents/chap06_04_3.tex
+++ b/06/contents/chap06_04_3.tex
@@ -16,7 +16,7 @@
 \item 6: 秒
 \item 7: ミリ秒
 \end{itemize}
-さて、それではこの\ruby{情報}{じょう|ほう}を使って今日の年、月、日を読み上げさせてみましょう。 \textasciitilde /06/readdate.hsp をHSPスクリプトエディタで開いてください。\\
+さて、それではこの\ruby{情報}{じょう|ほう}を使って今日の年、月、日を読み上げさせてみましょう。 \textasciitilde /07/readdate.hsp をHSPスクリプトエディタで開いてください。\\
 
 \begin{lstlisting}[caption=readdate.hsp,label=readdate.hsp]
 #include "hsp3dish.as"

--- a/06/contents/chap06_04_4.tex
+++ b/06/contents/chap06_04_4.tex
@@ -1,6 +1,6 @@
 \newpage
 \section{OpenJTalkが読み上げる文字列に変数を使う (2)}
- \textasciitilde /06/readcalc.hsp をhspスクリプトエディタで開き、見てみてください。
+ \textasciitilde /07/readcalc.hsp をhspスクリプトエディタで開き、見てみてください。
 
 このプログラムは、足し算の結果を読み上げます。15行目の\code{wait}命令に注目してください。\code{mmplay}は音声を\ruby{再生}{さい|せい}した\ruby{瞬間}{しゅん|かん}に次の命令を実行し始めるので、この\code{wait}命令がないと直ちに「こたえはご」を読み上げ始めてしまい、2つの音声が重なって聞き取りづらくなってしまいます。これを\ruby{避}{さ}けるため、\code{wait}命令で1つめの読み上げが終わるまで待っています。\\
 

--- a/06/contents/chap06_05_2.tex
+++ b/06/contents/chap06_05_2.tex
@@ -5,7 +5,7 @@
 少ない単語を登録した単語辞書をJuliusに読み\ruby{込}{こ}ませたときの動作を確認しましょう。juliusで辞書ファイルを使うには、辞書ファイルを引数にして、\code{julius.sh}命令を使います。\\
 \code{julius.sh <辞書ファイル名.dic>}
 
-例えば \textasciitilde /06/に果物の単語を登録した辞書ファイル、kudamono.dicを用意しています。kudamono.dicに下の単語が登録されています。
+例えば \textasciitilde /07/に果物の単語を登録した辞書ファイル、kudamono.dicを用意しています。kudamono.dicに下の単語が登録されています。
 \begin{center}
 	りんご　みかん　ぶどう　もも　あけび　あんず　いちご　いちじく　かき　スイカ\\すもも　	なし　メロン
 \end{center}
@@ -13,19 +13,19 @@
 単語辞書を使うと、単語辞書なしで音声認識させたときよりも正確で高速に動作していると思います。これが単語の種類を\ruby{制限}{せい|げん}する\ruby{効果}{こう|か}です。みなさんがjuliusを使って何か作りたいと思ったときは単語辞書を作り、必要な言葉だけを認識させる方法を使うのがおすすめです。\\
 
 \begin{itembox}[c]{ディレクトリの移動}
-        Juliusを使ったサンプルプログラムや必要なファイルは \textasciitilde /06/に用意してあります。入力する引数を短くするためにディレクトリを移動しておきましょう。\\
+        Juliusを使ったサンプルプログラムや必要なファイルは \textasciitilde /07/に用意してあります。入力する引数を短くするためにディレクトリを移動しておきましょう。\\
 \end{itembox}
 
 \begin{tcolorbox}[title=\useOmetoi]
 \begin{enumerate}
-        \addex{ターミナルを開いて、 \textasciitilde /06/に移動しましょう。\\ヒント：cd  \textasciitilde /06/}
+        \addex{ターミナルを開いて、 \textasciitilde /07/に移動しましょう。\\ヒント：cd  \textasciitilde /07/}
         \addquiz{ターミナルにjulius.sh kudamono.dicと入力して、果物の名前を5\ruby{個}{こ}話しかけてみましょう。単語は何個認識されましたか？}
 \end{enumerate}
 \end{tcolorbox}
 
 \newpage
 \section{自分の単語辞書を作成する}
-それでは、実際に自分で単語辞書を作成・登録しましょう。大まかな流れは、まず人間が読める形式で辞書を作成します。次に、辞書をJuliusが読める形式に変換します。最後に、\ruby{変換}{へん|かん}した辞書をjuliusに読み込ませます。辞書は\ruby{識別子}{しき|べつ|し}と読み方のペアでできています。識別子とは、コンピュータが使うラベル（名前）です。辞書ファイルの例として \textasciitilde /06/kudamono.yomiがあります。\\
+それでは、実際に自分で単語辞書を作成・登録しましょう。大まかな流れは、まず人間が読める形式で辞書を作成します。次に、辞書をJuliusが読める形式に変換します。最後に、\ruby{変換}{へん|かん}した辞書をjuliusに読み込ませます。辞書は\ruby{識別子}{しき|べつ|し}と読み方のペアでできています。識別子とは、コンピュータが使うラベル（名前）です。辞書ファイルの例として \textasciitilde /07/kudamono.yomiがあります。\\
 
 （識別子（コンピュータが使うラベル）と読み方のペア）
 
@@ -62,7 +62,7 @@
 
 \begin{tcolorbox}[title=\useOmetoi]
 \begin{enumerate}
-\addex{ターミナルを開いて、 \textasciitilde /06/に移動しましょう。}
+\addex{ターミナルを開いて、 \textasciitilde /07/に移動しましょう。}
 \addex{kudamono.yomiに好きな果物を3つ追加してみましょう。}
 \addex{辞書ファイルを変換しましょう。\\ターミナルに\code{convert\_yomi.sh kudamono.yomi > kudamono.dic}と入力します。}
 \addex{果物を追加したkudamono.dicで音声認識をしてみましょう。\\ターミナルに\code{julius.sh kudamono.dic}と入力します。}

--- a/06/contents/chap06_05_3.tex
+++ b/06/contents/chap06_05_3.tex
@@ -79,7 +79,7 @@ ddim cm, 0}\\
 によって、文字列配列\code{word}と小数配列\code{cm}に認識結果が代入されます。\code{word}と\code{cm}は配列なので、次の\code{repeat}文でそれぞれの要素に対して、\code{cm}（単語信頼度）が0.5以上のもののみ\code{mes}命令を実行し、結果を画面に表示させています。\\
 \begin{tcolorbox}[title=\useOmetoi]
 \begin{enumerate}
-\addex{ターミナルを開いて、 \textasciitilde /06/に移動しましょう。}
+\addex{ターミナルを開いて、 \textasciitilde /07/に移動しましょう。}
 \addex{HSPでjulius.hspを実行しましょう。\\果物の名前を３つ話しかけて、認識されるか確かめてみましょう。}
 \end{enumerate}
 \end{tcolorbox}

--- a/06/contents/chap06_05_4.tex
+++ b/06/contents/chap06_05_4.tex
@@ -7,7 +7,7 @@
 このプログラムでは、\\
 \code{init\_julius "kudamono.dic"}\quad\\
 として、プログラムを実行しているディレクトリにある\code{kudamono.dic}ファイルを辞書として指定しています。dicファイルが格納されているディレクトリが、プログラムを実行しているディレクトリと異なる場合は、相対パスか絶対パスでディレクトリを指定します。HSPプログラムからファイルを指定する際に\textasciitilde は使用できないので注意しましょう。このプログラムで読み込んでいるkudamono.dicを絶対パスで指定すると、\\
-\code{init\_julius "/home/<ユーザ名>/06/kudamono.dic"}\\
+\code{init\_julius "/home/<ユーザ名>/07/kudamono.dic"}\\
 となります。
 
 

--- a/06/contents/chap06_05_5.tex
+++ b/06/contents/chap06_05_5.tex
@@ -55,13 +55,13 @@ repeat -1
 loop
 \end{lstlisting}
 
-HSPプログラムから、音声を使ってLEDをつけたり消したりしてみましょう。 \textasciitilde /06にonoff.yomiファイルがあります。これは音声でLEDのON/OFFをするための辞書ファイルです。この辞書ファイルはリスト\ref{onoff.yomi}のように書いてあります。ONとOFFが表示する文字、おんとおふが読み方です。これを\code{convert\_yomi.sh}を使って変換したものがonoff.dicです。onoff.dicを使って、音声からLEDを\ruby{制御}{せい|ぎょ}してみましょう。 \textasciitilde /06/ledbyvoice.hsp を開いてください。\\
+HSPプログラムから、音声を使ってLEDをつけたり消したりしてみましょう。 \textasciitilde /07にonoff.yomiファイルがあります。これは音声でLEDのON/OFFをするための辞書ファイルです。この辞書ファイルはリスト\ref{onoff.yomi}のように書いてあります。ONとOFFが表示する文字、おんとおふが読み方です。これを\code{convert\_yomi.sh}を使って変換したものがonoff.dicです。onoff.dicを使って、音声からLEDを\ruby{制御}{せい|ぎょ}してみましょう。 \textasciitilde /07/ledbyvoice.hsp を開いてください。\\
 
 \code{words}(\code{cnt})に認識された文字が代入されています。認識された文字がONなのかOFFか\code{if}文（条件分岐）を使って、LEDを制御しています。\\
 
 \begin{tcolorbox}[title=\useOmetoi]
 \begin{enumerate}
-\addex{ターミナルを開いて、 \textasciitilde /06/に移動しましょう。}
+\addex{ターミナルを開いて、 \textasciitilde /07/に移動しましょう。}
 \addex{ledbyvoice.hspをHSPスクリプトエディタで実行しましょう。}
 \addex{点灯させるLEDを変\ruby{更}{こう}しましょう。}
 \addex{時間があったらやりましょう。\\点灯させるための言葉を「つける」と「けす」に変更しましょう。}

--- a/06/slide06.tex
+++ b/06/slide06.tex
@@ -261,7 +261,7 @@
 \begin{frame}[fragile]
   \frametitle{文章を読み上げてもらう -1}
   
-  \begin{lstlisting}[title=\textasciitilde/06/openjtalk.hsp,label=openjtalk.hsp]
+  \begin{lstlisting}[title=\textasciitilde/07/openjtalk.hsp,label=openjtalk.hsp]
   #include "hsp3dish.as"
   #include "jtalk.as"
 
@@ -289,7 +289,7 @@
 
 \begin{frame}[fragile]
   \frametitle{声音を変えてみる -1}
-  \begin{lstlisting}[title=\textasciitilde/06/voice.hsp,label=voice.hsp]
+  \begin{lstlisting}[title=\textasciitilde/07/voice.hsp,label=voice.hsp]
   #include "hsp3dish.as"
   #include "jtalk.as"
 
@@ -319,7 +319,7 @@
 
 \begin{frame}[fragile]
   \frametitle{読み上げる文字列に変数を使う -1}
-  \begin{lstlisting}[title=\textasciitilde/06/readdate.hsp,label=readdate.hsp]
+  \begin{lstlisting}[title=\textasciitilde/07/readdate.hsp,label=readdate.hsp]
     #include "hsp3dish.as"
     #include "jtalk.as"
 
@@ -355,7 +355,7 @@
 
 \begin{frame}[fragile]
   \frametitle{読み上げる文字列に変数を使う -3}
-  \begin{lstlisting}[title=\textasciitilde/06/readcalc.hsp,label=readcalc.hsp]
+  \begin{lstlisting}[title=\textasciitilde/07/readcalc.hsp,label=readcalc.hsp]
     #include "hsp3dish.as"
     #include "jtalk.as"
 
@@ -377,7 +377,7 @@
 
 \begin{frame}[fragile]
   \frametitle{読み上げる文字列に変数を使う\\(コード続き)}
-  \begin{lstlisting}[title=\textasciitilde/06/readcalc.hsp,label=readcalc.hsp]
+  \begin{lstlisting}[title=\textasciitilde/07/readcalc.hsp,label=readcalc.hsp]
     <#blue#;答え計算#>
     kotae = a + b
 
@@ -591,7 +591,7 @@
 
 \begin{frame}[fragile]
   \frametitle{HSPで\\Juliusの認識結果を使おう -2}
-  \begin{lstlisting}[title=\textasciitilde/06/julius.hsp,label=julius.hsp]
+  \begin{lstlisting}[title=\textasciitilde/07/julius.hsp,label=julius.hsp]
   #include "hsp3dish.as"
   #include "julius.as"
 
@@ -611,7 +611,7 @@
 
 \begin{frame}[fragile]
   \frametitle{HSPで\\Juliusの認識結果を使おう -3}
-  \begin{lstlisting}[title=\textasciitilde/06/julius.hsp,label=julius.hsp]
+  \begin{lstlisting}[title=\textasciitilde/07/julius.hsp,label=julius.hsp]
   sockopen sockidx, domain, PORT
 
   if stat != 0 { <#blue#;エラー処理#>
@@ -633,7 +633,7 @@
 
 \begin{frame}[fragile]
   \frametitle{HSPで\\Juliusの認識結果を使おう -4}
-  \begin{lstlisting}[title=\textasciitilde/06/julius.hsp,label=julius.hsp,basicstyle=\scriptsize]
+  \begin{lstlisting}[title=\textasciitilde/07/julius.hsp,label=julius.hsp,basicstyle=\scriptsize]
   repeat -1
     if is_recieved(sockidx) = 0 {
       get_word_list words, cm
@@ -666,7 +666,7 @@
 
 \begin{frame}[fragile]
   \frametitle{音声でLEDのON OFFをする -1}
-  \begin{lstlisting}[title=\textasciitilde/06/ledvoice.hsp,label=ledvoice.hsp]
+  \begin{lstlisting}[title=\textasciitilde/07/ledvoice.hsp,label=ledvoice.hsp]
     #include "hsp3dish.as"
     #include "julius.as"
 
@@ -675,7 +675,7 @@
     mes "Loading Julius..."
     redraw 1
 
-    init_julius " \textasciitilde /06/onoff.dic" <#blue#;辞書を読み込む#>
+    init_julius "/07/onoff.dic" <#blue#;辞書を読み込む#>
 
     sockidx = 0
     domain = "127.0.0.1"
@@ -686,7 +686,7 @@
 
 \begin{frame}[fragile]
   \frametitle{音声でLEDのON OFFをする -2}
-  \begin{lstlisting}[title=\textasciitilde/06/ledvoice.hsp,label=ledvoice.hsp]
+  \begin{lstlisting}[title=\textasciitilde/07/ledvoice.hsp,label=ledvoice.hsp]
     if stat != 0 {
       redraw 0
       mes "Error in opening socket"
@@ -703,7 +703,7 @@
 
 \begin{frame}[fragile]
   \frametitle{音声でLEDのON OFFをする -3}
-  \begin{lstlisting}[title=\textasciitilde/06/ledvoice.hsp,label=ledvoice.hsp,basicstyle=\scriptsize]
+  \begin{lstlisting}[title=\textasciitilde/07/ledvoice.hsp,label=ledvoice.hsp,basicstyle=\scriptsize]
     repeat -1
     if is_recieved(sockidx) = 0 {
       get_word_list words, cm


### PR DESCRIPTION
## 教科書
- ディレクトリをコピーするとき06から07に名前を変更するように明記した
- ターミナルを用いた教材のコピー方法を追加した
- 06ディレクトリを参照していた箇所を07参照にした
## スライド
- 06ディレクトリを参照していた箇所を07参照にした
## 気になったところ
- スライドで06ディレクトリの名前を07に変更するするように指示するスライドがない

close #648 