### PR TITLE
Add GitHub Workflow to build & push container image into github container registory

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,40 @@
+name: Build and Push ome-doc Container Image
+
+on:
+  push:
+    tags:
+      - "*"
+      - "buildenv/**"
+    branches:
+      - "workflow-dev"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ome-doc
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create the GitHub Repository Name with All Small Cases
+      run: |
+        echo "REPOSITORY_NAME_LC=${REPOSITORY_NAME,,}" >>"${GITHUB_ENV}"
+      env:
+        REPOSITORY_NAME: '${{ github.repository }}'
+    - name: Build and Push Container
+      uses: docker/build-push-action@v5
+      with:
+        push: true
+        tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME_LC }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+
+# Inherited by https://qiita.com/Jazuma/items/aca397e081a7825d0dec


### PR DESCRIPTION
This commit enables you to pull container image that perform typesetting. 

To do so, navigate to Packages page in the project. https://github.com/orgs/OmeSatoFoundation/packages?repo_name=ome-doc
Then click a package name and you will see a command to pull the container. e.g.,

```bash
$ docker pull ghcr.io/omesatofoundation/ome-doc/ome-doc:workflow-dev
```

This feature wonderfully saves time to build container images in local computers, which includes texlive installation.