### PR TITLE
fix text03

### DIFF
--- a/03/contents/chap03_110_Terminal.tex
+++ b/03/contents/chap03_110_Terminal.tex
@@ -85,6 +85,8 @@ bashでは、入力したい文字の\ruby{途中}{と|ちゅう}まで入力し
 \begin{itemize}
 \item[<例>]コマンドを入力する途中で Tab キーを使ってみます。
 \end{itemize}
+
+みなさんの実行結果と教科書の実行結果では違う場合があります。
 \begin{lstlisting}[caption=Tabの例1, label=Tab1]
 <#green#pi@raspberrypi#>:<#blue#~ $#> pw
 pw-cat         pwd            pw-metadata    pw-mon         pw-reserve

--- a/03/contents/chap03_130_Commands01.tex
+++ b/03/contents/chap03_130_Commands01.tex
@@ -80,8 +80,8 @@ https:／／www.aozora.gr.jp/cards/000121/files/628_14895.html<#green#pi@raspber
 \begin{lstlisting}[caption=cpの例, label=cp]
 <#green#pi@raspberrypi#>:<#blue#~ $#> cp ~/03/rensyu/rika/rika.png ~/rika2.png
 <#green#pi@raspberrypi#>:<#blue#~ $#> ls -F
-<#blue#01/  03/         Desktop/    Downloads/  Pictures/#>  <#magenta#rika2.png#>   <#blue#Videos/#>
-<#blue#02/  Bookshelf/  Documents/  Music/      Public/    Templates/#>
+<#blue#01/  03/         Desktop/    Downloads/  Pictures/  Templates/#>  <#magenta#rika2.png#>
+<#blue#02/  Bookshelf/  Documents/  Music/      Public/    Videos/#>
 \end{lstlisting}
 \begin{description}
 \item[\texttt{cp}\textvisiblespace \texttt{-r}\textvisiblespace \underline{ディレクトリ1}\textvisiblespace \underline{ディレクトリ2}]\mbox{}\\
@@ -93,8 +93,8 @@ https:／／www.aozora.gr.jp/cards/000121/files/628_14895.html<#green#pi@raspber
 \begin{lstlisting}[caption=cp -rの例, label=cp-R]
 <#green#pi@raspberrypi#>:<#blue#~ $#> cp -r ~/03/rensyu/rika ~/rika
 <#green#pi@raspberrypi#>:<#blue#~ $#> ls -F
-<#blue#01/  03/         Desktop/    Downloads/  Pictures/  rika/      Templates/#>
-<#blue#02/  Bookshelf/  Documents/  Music/      Public/#>    <#magenta#rika2.png#>  <#blue#Videos/#>
+<#blue#01/  03/         Desktop/    Downloads/  Pictures/  Templates/   rika/#>
+<#blue#02/  Bookshelf/  Documents/  Music/      Public/    Videos/#>      <#magenta#rika2.png#>
 \end{lstlisting}
 
 \newpage
@@ -125,7 +125,7 @@ https:／／www.aozora.gr.jp/cards/000121/files/628_14895.html<#green#pi@raspber
 <#green#pi@raspberrypi#>:<#blue#~ $#> cd ~/rika
 <#green#pi@raspberrypi#>:<#blue#~ $#> mv rika2.png bika.png
 <#green#pi@raspberrypi#>:<#blue#~ $#> ls -F
-<#magenta#bika.png	mokei.png		rika.png#>
+<#magenta#bika.png	mokei.png     rika.png#>
 \end{lstlisting}
 
 \begin{tcolorbox}[title=\useOmetoi]

--- a/03/contents/chap03_140_Commands02.tex
+++ b/03/contents/chap03_140_Commands02.tex
@@ -70,8 +70,8 @@ mousepad を使って\underline{ファイル}を作成または\ruby{編集}{へ
 \begin{lstlisting}[caption=mkdirの例, label=mkdir]
 <#green#pi@raspberrypi#>:<#blue#~ $#> mkdir my
 <#green#pi@raspberrypi#>:<#blue#~ $#> ls -F
-<#blue#01/  03/         Desktop/    Downloads/  my/     Pictures/  rika/       Videos/#>
-<#blue#02/  Bookshelf/  Documents/  Music/#>      my.txt  <#blue#Public/    Templates/#>
+<#blue#01/  03/         Desktop/    Downloads/  Pictures/  Templates/   my/   rika/#>
+<#blue#02/  Bookshelf/  Documents/  Music/      Public/    Viodeos/#>     my.txt
 \end{lstlisting}
 
 \subsection{ファイルやディレクトリを消してみよう}
@@ -84,12 +84,12 @@ mousepad を使って\underline{ファイル}を作成または\ruby{編集}{へ
 \end{itemize}
 \begin{lstlisting}[caption=rmの例, label=rm]
 <#green#pi@raspberrypi#>:<#blue#~ $#> ls -F
-<#blue#01/  03/         Desktop/    Downloads/  my/     Pictures/  rika/       Videos/#>
-<#blue#02/  Bookshelf/  Documents/  Music/#>      my.txt  <#blue#Public/    Templates/#>
+<#blue#01/  03/         Desktop/    Downloads/  Pictures/  Templates/   my/   rika/#>
+<#blue#02/  Bookshelf/  Documents/  Music/      Public/    Viodeos/#>     my.txt
 <#green#pi@raspberrypi#>:<#blue#~ $#> rm my.txt
 <#green#pi@raspberrypi#>:<#blue#~ $#> ls -F
-<#blue#01/  03/         Desktop/    Downloads/  my/        Public/  Templates/#>
-<#blue#02/  Bookshelf/  Documents/  Music/      Pictures/  rika/    Videos/#>
+<#blue#01/  03/         Desktop/    Downloads/  Pictures/  Templates/   my/#>
+<#blue#02/  Bookshelf/  Documents/  Music/      Public/    Viodeos/     rika/#>     
 \end{lstlisting}
 \begin{description}
 \item[● \texttt{rm}\textvisiblespace \texttt{-r}\textvisiblespace \underline{ディレクトリ}$\ldots$]\mbox{}\\
@@ -101,12 +101,12 @@ mousepad を使って\underline{ファイル}を作成または\ruby{編集}{へ
 \end{itemize}
 \begin{lstlisting}[caption=rm -rの例, label=rm-R]
 <#green#pi@raspberrypi#>:<#blue#~ $#> ls -F
-<#blue#01/  03/         Desktop/    Downloads/  my/        Public/  Templates/#>
-<#blue#02/  Bookshelf/  Documents/  Music/      Pictures/  rika/    Videos/#>
+<#blue#01/  03/         Desktop/    Downloads/  Pictures/  Templates/   my/#>
+<#blue#02/  Bookshelf/  Documents/  Music/      Public/    Viodeos/     rika/#>     
 <#green#pi@raspberrypi#>:<#blue#~ $#> rm -r my
 <#green#pi@raspberrypi#>:<#blue#~ $#> ls -F
-<#blue#01/  03/         Desktop/    Downloads/  Pictures/  rika/       Videos/#>
-<#blue#02/  Bookshelf/  Documents/  Music/      Public/    Templates/#>
+<#blue#01/  03/         Desktop/    Downloads/  Pictures/  Templates/   rika/#>
+<#blue#02/  Bookshelf/  Documents/  Music/      Public/    Videos/#>
 \end{lstlisting}
 
 \begin{tcolorbox}[title=\useOmetoi]

--- a/03/contents/chap03_310_AdvancedCommands.tex
+++ b/03/contents/chap03_310_AdvancedCommands.tex
@@ -195,8 +195,8 @@ EOFはファイルがここで終ることを示す記号です。End Of File(�
 \end{figure}
 \begin{lstlisting}[caption=lsの出力をリダイレクトする, label=redirectLs]
 <#green#pi@raspberrypi#>:<#blue#~ $#> ls 
-<#blue#01  03         Desktop    Downloads  Pictures  Templates
-02  Bookshelf  Documents  Music      Public    Videos#>
+<#blue#01  03         Desktop    Downloads  Pictures  Templates   rika#>
+<#blue#02  Bookshelf  Documents  Music      Public    Videos#>
 <#green#pi@raspberrypi#>:<#blue#~ $#> ls > lsfile
 <#green#pi@raspberrypi#>:<#blue#~ $#> cat lsfile
 01
@@ -212,7 +212,7 @@ Public
 Templates
 Videos
 lsfile
-testtouch
+rika
 \end{lstlisting}
 
 「>(大なり記号)」の後にファイル名を指定することで、
@@ -236,7 +236,7 @@ Public
 Templates
 Videos
 lsfile
-testtouch
+rika
 \end{lstlisting}
 
 ちなみに、"cat lsfile"と入力しても動作は同じです。
@@ -272,7 +272,7 @@ Public
 Templates
 Videos
 lsfile
-testtouch
+rika
 ~
 ~
 ~
@@ -320,8 +320,9 @@ lessコマンドにlsコマンドの\ruby{標準}{ひょう|じゅん}出力を�
 次に、具体的な例を見てみましょう
 \begin{lstlisting}[caption=tacコマンドの実行例, label=tac_example]
 <#green#pi@raspberrypi#>:<#blue#~ $#> tac ~/lsfile
-testtouch
+rika
 lsfile
+keytest
 Videos
 Templates
 Public
@@ -387,7 +388,7 @@ Downloads
 \begin{lstlisting}[caption=tailコマンドの実行例, label=shuf_example]
 <#green#pi@raspberrypi#>:<#blue#~ $#> tail -n 2 ~/lsfile
 lsfile
-testtouch
+rika
 \end{lstlisting}
 この例では、lsfileの中身の末尾の2行を表示しました。
 
@@ -412,8 +413,9 @@ Pictures
 Public
 Templates
 Videos
+keytest
 lsfile
-testtouch
+rika
 \end{lstlisting}
 この例では、lsfileの中身を順番に並べ替えて表示してみました。
 数字とアルファベットが\ruby{混在}{こん|ざい}している場合、数字が先に表示され、その後にアルファベットが表示されます。
@@ -464,8 +466,9 @@ Pictures
 Public
 Templates
 Videos
+keytest
 lsfile
-testtouch
+rika
 \end{lstlisting}
 
 この例では、lsコマンドでホームディレクトリの中身を表示し、その結果をsortコマンドに渡して並べ替えています。

--- a/03/contents/chap03_320_PipeAndRedirect.tex
+++ b/03/contents/chap03_320_PipeAndRedirect.tex
@@ -232,11 +232,11 @@ Bashの機能を使って、計算をしてみましょう。
 コマンドの中で使用される \$() はコマンド\ruby{置換}{ち|かん}を行うための\ruby{構文}{こう|ぶん}です。コマンド\ruby{置換}{ち|かん}を使用すると、中のコマンドの\ruby{実行結果}{じっ|こう|けっ|か}を、別のコマンドの\ruby{引数}{ひき|すう}として使用することができます。
 \begin{lstlisting}[caption=echo コマンド置換を使った例1, label=cmdsbs:echo]
 <#green#pi@raspberrypi#>:<#blue#~/ $#> echo $(ls)
-01 02 03 Bookshelf Desktop Documents Downloads Music Pictures Public Templates Videos lsfile r
-ika
+01 02 03 Bookshelf Desktop Documents Downloads Music Pictures Public Templates Videos keytest
+lsfile rika
 <#green#pi@raspberrypi#>:<#blue#~/ $#> ls
-<#blue#01  03         Desktop    Downloads  Pictures  Templates#> lsfile
-<#blue#02  Bookshelf  Documents  Music      Public    Videos    rika#> 
+<#blue#01  03         Desktop    Downloads  Pictures  Templates#>   keytest   <#blue#rika#>
+<#blue#02  Bookshelf  Documents  Music      Public    Videos#>      lsfile
 \end{lstlisting}
 コマンド置換でlsの\ruby{結果}{けっ|か}が\ruby{表示}{ひょう|じ}されることがわかります。
 
@@ -370,7 +370,7 @@ findコマンドは、ディレクトリの中から指定されたファイル�
 \begin{lstlisting}[caption=ワイルドカードの使い方, label=wildcard]
 <#green#pi@raspberrypi#>:<#blue#~ $#> find -name rika.png
 ./rika/rika.png
-./03/rensyu/rika.png
+./03/rensyu/rika/rika.png
 <#green#pi@raspberrypi#>:<#blue#~ $#>
 \end{lstlisting}
 
@@ -420,7 +420,7 @@ findコマンドは、波かっこ\{,\}以外のワイルドカードを使っ�
 <#green#pi@raspberrypi#>:<#blue#~ $#> find 03 -name '*.png'
 03/rensyu/rika/rika.png
 03/rensyu/rika/mokei.png
-03/rensyu/syakai/nihon.png
+03/rensyu/sansu/nihon.png
 03/rensyu/syakai/sekai.png
 \end{lstlisting}
 


### PR DESCRIPTION
close #669 

リスト3.5 注釈を追加

リスト3.11-3.12, 3.18-3.20 ディレクトリの表示順の修正

リスト3.26~27は再度実行したら同じ結果だったため、修正なし

リスト3.35~3.38 touchtestの削除 & rikaディレクトリの追加

リスト3.63
pi@raspberrypi:~ $ find-name rika.png
 ./rika/rika.png
./03/rensyu/rika.png    ->   ./03/rensyu/rika/rika.pngに変更

リスト3.65 
03/rensyu/syakai/nihon.png -> 03/rensyu/sansu/nihon.png